### PR TITLE
Testing

### DIFF
--- a/ale/drivers/mro_driver.py
+++ b/ale/drivers/mro_driver.py
@@ -95,17 +95,3 @@ class CtxPds3Driver(PDS3, CtxSpice):
             'MARS_RECONNAISSANCE_ORBITER': 'MRO'
         }
         return name_lookup[self.label['SPACECRAFT_NAME']]
-
-    @property
-    def instrument_id(self):
-        """
-        Returns an instrument id for unquely identifying the instrument, but often
-        also used to be piped into Spice Kernels to acquire IKIDs. Therefore they
-        the same ID the Spice expects in bods2c calls.
-
-        Returns
-        -------
-        : str
-          instrument id
-        """
-        return self.id_lookup[self.label['INSTRUMENT_NAME']]

--- a/tests/pytests/conftest.py
+++ b/tests/pytests/conftest.py
@@ -1,26 +1,55 @@
 import numpy as np
 
+def check_key(f):
+    def wrapper(*args):
+        obj = args[0]  # This is the class instance; self
+        key = args[1]  # We assume the first arg is the key
+        assert key in obj.pool_keys
+        return f(*args)
+    return wrapper
+
 class SimpleSpice():
+    def __init__(self, pool_keys=[]):
+        base_keys = ['INS-12345_CCD_CENTER',
+                     'INS-12345_FOCAL_LENGTH',
+                     'INS-12345_ITRANSL',
+                     'INS-12345_ITRANSS',
+                     'INSTRUMENT_NAME',
+                     'SPACECRAFT_NAME']
+        self.pool_keys = pool_keys + base_keys
+
     def scs2e(self, *args):
         return 0.1
+    
     def bods2c(self, x):
         return -12345
+    
+    @check_key
     def gdpool(self, key, x, length):
         return np.ones(length)
+    
+    @check_key
     def bodvrd(self, key, x, length):
         return (3, np.ones(length,))
+    
     def spkpos(self, *args):
         return (np.ones(3), None)
+    
     def spkezr(self, *args):
         return (np.ones(6), None)
+    
     def furnsh(self, *args):
         return
+    
     def unload(self, *args):
         return
+    
     def pxform(self, *args):
         return
+    
     def m2q(self, *args):
         return np.asarray([1,2,3,4])
+    
     def bodn2c(self, *args):
         return "SPACE"
 

--- a/tests/pytests/test_lro_drivers.py
+++ b/tests/pytests/test_lro_drivers.py
@@ -8,14 +8,8 @@ from ale.drivers import lro_driver, base
 from ale.drivers.lro_driver import LrocPds3Driver
 from ale import util
 
-# 'Mock' the spice module where it is imported
 from conftest import SimpleSpice, get_mockkernels
 
-simplespice = SimpleSpice()
-base.spice = simplespice
-lro_driver.spice = simplespice
-
-LrocPds3Driver.metakernel = get_mockkernels
 
 @pytest.fixture
 def lro_lroclabel():
@@ -110,6 +104,16 @@ def lro_lroclabel():
         END_OBJECT                         = IMAGE
         END
         """
+
+@pytest.fixture
+def lropds_driver():
+  pool_keys = ['MOON']
+
+  # Setup a kernel pool fixture for PDS3 driver testing
+  simplespice = SimpleSpice(pool_keys)
+  base.spice = simplespice
+  lro_driver.spice = simplespice
+  LrocPds3Driver.metakernel = get_mockkernels
 
 def test_lro_creation(lro_lroclabel):
     with LrocPds3Driver(lro_lroclabel) as m:

--- a/tests/pytests/test_mdis_driver.py
+++ b/tests/pytests/test_mdis_driver.py
@@ -7,15 +7,7 @@ import ale
 from ale.drivers import mdis_driver, base
 from ale.drivers.mdis_driver import MdisPDS3Driver
 
-
-# 'Mock' the spice module where it is imported
 from conftest import SimpleSpice, get_mockkernels
-
-simplespice = SimpleSpice()
-base.spice = simplespice
-mdis_driver.spice = simplespice
-
-MdisPDS3Driver.metakernel = get_mockkernels
 
 @pytest.fixture
 def mdislabel():
@@ -243,7 +235,19 @@ END_OBJECT = IMAGE
 END
     """
 
-def test_mdis_creation(mdislabel):
+@pytest.fixture
+def mdispds_driver():
+  pool_keys = ['INS-12345_FL_UNCERTAINTY', 'INS-12345_FL_TEMP_COEFFS ', 'EARTH',
+               'INS-12345_FPUBIN_START_LINE',
+               'INS-12345_FPUBIN_START_SAMPLE']
+
+  # Setup a kernel pool fixture for PDS3 driver testing
+  simplespice = SimpleSpice(pool_keys)
+  base.spice = simplespice
+  mdis_driver.spice = simplespice
+  MdisPDS3Driver.metakernel = get_mockkernels
+
+def test_mdis_creation(mdispds_driver, mdislabel):
     with MdisPDS3Driver(mdislabel) as m:
         d = m.to_dict()
         assert isinstance(d, dict)

--- a/tests/pytests/test_mro_drivers.py
+++ b/tests/pytests/test_mro_drivers.py
@@ -4,7 +4,6 @@ import ale
 from ale.drivers.mro_driver import CtxPds3Driver
 from ale.drivers import mro_driver, base
 
-# 'Mock' the spice module where it is imported
 from conftest import SimpleSpice, get_mockkernels
 
 @pytest.fixture
@@ -55,6 +54,7 @@ def mroctx_label():
     END_OBJECT = IMAGE
     END"""
 
+@pytest.fixture
 def mroctxpds_driver():
     pool_keys = ['INS-12345_OD_K', 'MARS']
 
@@ -65,7 +65,15 @@ def mroctxpds_driver():
     CtxPds3Driver.metakernel = get_mockkernels
     return
 
-def test_ctx_creation(mroctx_label):
+def test_ctx_creation(mroctxpds_driver, mroctx_label):
     with CtxPds3Driver(mroctx_label) as m:
         d = m.to_dict()
     assert isinstance(d, dict)
+
+def test_ctx_instrument_id(mroctxpds_driver, mroctx_label):
+    with CtxPds3Driver(mroctx_label) as m:
+        assert m.instrument_id == 'MRO_CTX'
+
+def test_ctx_spacecraft_name(mroctxpds_driver, mroctx_label):
+    with CtxPds3Driver(mroctx_label) as m:
+        assert m.spacecraft_name == 'MRO'

--- a/tests/pytests/test_mro_drivers.py
+++ b/tests/pytests/test_mro_drivers.py
@@ -7,12 +7,6 @@ from ale.drivers import mro_driver, base
 # 'Mock' the spice module where it is imported
 from conftest import SimpleSpice, get_mockkernels
 
-simplespice = SimpleSpice()
-base.spice = simplespice
-mro_driver.spice = simplespice
-
-CtxPds3Driver.metakernel = get_mockkernels
-
 @pytest.fixture
 def mroctx_label():
     return """
@@ -61,6 +55,15 @@ def mroctx_label():
     END_OBJECT = IMAGE
     END"""
 
+def mroctxpds_driver():
+    pool_keys = ['INS-12345_OD_K', 'MARS']
+
+    # Setup a kernel pool fixture for PDS3 driver testing
+    simplespice = SimpleSpice(pool_keys)
+    base.spice = simplespice
+    mro_driver.spice = simplespice
+    CtxPds3Driver.metakernel = get_mockkernels
+    return
 
 def test_ctx_creation(mroctx_label):
     with CtxPds3Driver(mroctx_label) as m:


### PR DESCRIPTION
How this works: The `SimpleSpice` class has been extended to have a bit more fixture logic that makes checks for keys for `gdpool` and `bodvrd`. This is acocmplished via a decorator with an assertion. Failures raise nicely through pytest.

Implementation: Each driver (and flavor) that defines unique keys can add them into a `pool_keys` variable within the test. This requires that a dev add the key in two places (in the driver and in the test). I would suggest that this is a positive cognitive load as it hopefully pushes us to (1) look at kernels, (2) write the test, (3) implement. MDIS is the most 'unique' of the currently implemented so check that out for a better view of the extent of this. Thoughts?

Quality of Tests: The MRO test is furthest along on how we might test things. We need to have a rich base test and then we can rely on `pool_key`, `*_creation`, and individual tests for overriding methods.

Concerns:

`*_driver` fixtures are janky. We can literally mislabel the `*.metakernel = get_mockkernels` with the wrong instrument and get a passing test. This is because of how simple `SimpleSpice` really is. If we carried instrument codes this would break, but why write a test for a test. We also probably can't get more generic with `SimpleSpice` and centralize the fixture with making a parametrized fixture that dynamically injects the instrument specific pool keys. This is an option though.

`bodvrd` - I had a moment of concern with the key check on this for MDIS because the key we are checking for is `Earth`. The mission is nominally Mercury facing. This is not a big deal since the validation is just on the key, but it brings up a good point: if we only ever get body information, do we really care to check the key on this at all?