### PR TITLE
Add python setup.py to build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ After you've set up and activated your conda environment, you may then build ale
 of a cloned fork of the repository, follow these steps:
 
 ```bash
+python setup.py install
 mkdir build && cd build
 cmake ..
 make


### PR DESCRIPTION
I noticed that our build instructions as written don't work. I added the `python setup.py install` step. (I usually do `python setup.py develop` but I wasn't sure that that made sense for the default build instructions.)