### PR TITLE
Fixes parent/child warning in test suite

### DIFF
--- a/ale/transformation.py
+++ b/ale/transformation.py
@@ -41,9 +41,12 @@ class FrameNode():
         self.children = []
         self.id = id
         if parent is not None:
-            self._parent = parent
+            self.parent = parent
         if rotation is not None:
             self.rotation = rotation
+
+    def __repr__(self):
+        return f'ID:{self.id}\nChildren:{self.children}'
 
     def __del__(self):
         """
@@ -72,7 +75,7 @@ class FrameNode():
         of the old parent and adds it to the children of the new parent.
         """
         if self.parent is not None:
-            self.parent.children.remove(self)
+            self._parent.children.remove(self)
 
         new_parent.children.append(self)
         self._parent = new_parent

--- a/tests/pytests/test_transformation.py
+++ b/tests/pytests/test_transformation.py
@@ -4,8 +4,8 @@ import numpy as np
 from ale.rotation import ConstantRotation
 from ale.transformation import FrameNode
 
-@pytest.fixture
-def frame_tree():
+@pytest.fixture(scope='function')
+def frame_tree(request):
     """
     Test frame tree structure:
 
@@ -33,6 +33,14 @@ def frame_tree():
         child_node_3
     ]
     return (nodes, rotations)
+
+def test_del_node(frame_tree):
+    nodes, _ = frame_tree
+    node3 = nodes[3]
+    node2 = nodes[2]
+    del node3
+    
+    assert len(node2.children) == 0
 
 def test_parent_nodes(frame_tree):
     nodes, _ = frame_tree


### PR DESCRIPTION
This PR:

- Adds a test for removing a child
- Minor update to the public/private structure on the constructor in order to get children properly adding to the parent
- Adds a `__repr__` to the nodes that I was using to debug. I can back this out of we think it is unnecessary.

All tests passing locally. I am seeing 1 warning, but it is inside the PVL module (collections).