### PR TITLE
First pass at adding frame chain to NaifSpice class

### DIFF
--- a/ale/base/data_naif.py
+++ b/ale/base/data_naif.py
@@ -1,6 +1,7 @@
 import spiceypy as spice
 import numpy as np
 from ale.base.type_sensor import Framer
+from ale.transformation import FrameNode
 
 class NaifSpice():
     def __enter__(self):
@@ -150,10 +151,22 @@ class NaifSpice():
 
     @property
     def frame_chain(self):
-        pass
+        # pass
+        if not hasattr(self, '_frame_chain'):
+            frame_chain = {}
+            frame_chain['j2000'] = FrameNode(1)
+            # self._frame_chain['spacecraft'] = FrameNode(self.)
+            frame_chain['sensor'] = FrameNode(self.sensor_frame_id, 
+                                                parent=frame_chain['j2000'],
+                                                rotation='ConstantRotation')
+            frame_chain['target'] = FrameNode(self.target_frame_id, 
+                                                 parent=frame_chain['j2000'],
+                                                 rotation='TimeDependentRotation')
+            self._frame_chain = frame_chain
+        return self._frame_chain
 
     @property
-    def _sensor_orientation(self):
+    def sensor_orientation(self):
         if not hasattr(self, '_orientation'):
             ephem = self.ephemeris_time
 

--- a/tests/pytests/test_data_naif.py
+++ b/tests/pytests/test_data_naif.py
@@ -18,6 +18,10 @@ def test_naif_data():
 
     return naif_data
 
+def test_frame_chain(test_naif_data):
+    assert test_naif_data.frame_chain['j2000'].parent == None
+    assert test_naif_data.frame_chain['target'].parent == test_naif_data.frame_chain['j2000']
+
 def test_target_id(test_naif_data):
     assert test_naif_data.target_id == -12345
 


### PR DESCRIPTION
I have not figured out yet how to access the spacecraft frame NAIF ID yet, but once I get that figured out, I will get it implemented.

I wanted to get this up for feedback as soon as possible, though. I went with a dictionary format since any NaifSpice object was going to have the same four frame nodes (j2000, spacecraft, sensor, and target).

Any feedback appreciated! This references https://github.com/USGS-Astrogeology/ale/issues/164