### PR TITLE
Cassini ISS - rotation fix?

### DIFF
--- a/ale/rotation.py
+++ b/ale/rotation.py
@@ -164,7 +164,6 @@ class TimeDependentRotation:
         The destination frame of the right rotation (other) and the source
         frame of the left rotation (self) must be the same. I.E. if A and B are
         rotations, then for A*B to be valid, A.source must equal B.dest. 
-        # typo? A.dest = B.source? 
 
         If the other rotation is a time dependent rotation, then the time range
         for the resultant rotation will be the time covered by both rotations.
@@ -182,7 +181,7 @@ class TimeDependentRotation:
         elif isinstance(other, TimeDependentRotation):
             # if self and other each have the same time and one rotation, don't interpolate.
             if (self.times.size == 1) and (other.times.size == 1) and (self.times == other.times):
-                    return TimeDependentRotation((self._rots * other._rots).as_quat(), self.times, other.source, self.dest)
+                return TimeDependentRotation((self._rots * other._rots).as_quat(), self.times, other.source, self.dest)
             merged_times = np.union1d(np.asarray(self.times), np.asarray(other.times))
             # we cannot extrapolate so clip to the time range both cover
             first_time = max(min(self.times), min(other.times))

--- a/ale/rotation.py
+++ b/ale/rotation.py
@@ -179,6 +179,10 @@ class TimeDependentRotation:
         if isinstance(other, ConstantRotation):
             return TimeDependentRotation((self._rots * other._rot).as_quat(), self.times, other.source, self.dest)
         elif isinstance(other, TimeDependentRotation):
+            # if self and other each have the same time and one rotation, don't interpolate.
+            if (self.times.size == 1) and (other.times.size == 1):
+                if (self.times == other.times):
+                    return TimeDependentRotation((self._rots * other._rots).as_quat(), self.times, other.source, other.dest)
             merged_times = np.union1d(np.asarray(self.times), np.asarray(other.times))
             # we cannot extrapolate so clip to the time range both cover
             first_time = max(min(self.times), min(other.times))

--- a/ale/rotation.py
+++ b/ale/rotation.py
@@ -163,7 +163,8 @@ class TimeDependentRotation:
 
         The destination frame of the right rotation (other) and the source
         frame of the left rotation (self) must be the same. I.E. if A and B are
-        rotations, then for A*B to be valid, A.source must equal B.dest.
+        rotations, then for A*B to be valid, A.source must equal B.dest. 
+        # typo? A.dest = B.source? 
 
         If the other rotation is a time dependent rotation, then the time range
         for the resultant rotation will be the time covered by both rotations.
@@ -180,9 +181,8 @@ class TimeDependentRotation:
             return TimeDependentRotation((self._rots * other._rot).as_quat(), self.times, other.source, self.dest)
         elif isinstance(other, TimeDependentRotation):
             # if self and other each have the same time and one rotation, don't interpolate.
-            if (self.times.size == 1) and (other.times.size == 1):
-                if (self.times == other.times):
-                    return TimeDependentRotation((self._rots * other._rots).as_quat(), self.times, other.source, other.dest)
+            if (self.times.size == 1) and (other.times.size == 1) and (self.times == other.times):
+                    return TimeDependentRotation((self._rots * other._rots).as_quat(), self.times, other.source, self.dest)
             merged_times = np.union1d(np.asarray(self.times), np.asarray(other.times))
             # we cannot extrapolate so clip to the time range both cover
             first_time = max(min(self.times), min(other.times))


### PR DESCRIPTION
I updated `__mul__` in `TimeDependentRotation` to not even try to interpolate if self and other have one time and it's the same time, to get Cassini working. I'm not sure that this was the right solution and I seem to recall discussion about doing something else here? Reviewers, if you remember or have better ideas let me know.

Also, the mro config location update that came along for the ride is unrelated, but useful.