### PR TITLE
added data area change script

### DIFF
--- a/bin/change_mk_data_path.py
+++ b/bin/change_mk_data_path.py
@@ -13,16 +13,23 @@ args = parser.parse_args()
 
 mks = glob(path.join(args.mk_path,'*.tm'))
 
+
+
 for mk in mks:
     with open(mk, 'r') as f:
         lines = f.readlines()
 
-    lines_to_change = [i for i,l in enumerate(lines) if 'PATH_VALUES     =' in l]
+    lines_to_change = []
+    for i,l in enumerate(lines):
+        match = re.search('PATH_VALUES\s*=', l)
+        if match:
+            lines_to_change.append(i)
+
     if not lines_to_change:
         print(f'No path values in {mk}')
 
     for i in lines_to_change:
-        lines[i] = f'      PATH_VALUES     = ( \'{args.new_data_path}\' )\n'
-
+        lines[i] = f'      PATH_VALUES     = ( \'{new_data_dir}\' )\n'
     with open(mk, 'w') as f:
         f.write(''.join(lines))
+

--- a/bin/change_mk_data_path.py
+++ b/bin/change_mk_data_path.py
@@ -10,10 +10,7 @@ parser.add_argument('mk_path', action='store', help='Path containing metakernel 
 parser.add_argument('new_data_path', action='store', help='new data path containing kernel, this path will overwrite the current data path in the metakernels')
 args = parser.parse_args()
 
-
 mks = glob(path.join(args.mk_path,'*.tm'))
-
-
 
 for mk in mks:
     with open(mk, 'r') as f:

--- a/bin/change_mk_data_path.py
+++ b/bin/change_mk_data_path.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+
+import argparse
+from glob import glob
+from os import path
+import re
+
+parser = argparse.ArgumentParser()
+parser.add_argument('mk_path', action='store', help='Path containing metakernel (*.tm) files.')
+parser.add_argument('new_data_path', action='store', help='new data path containing kernel, this path will overwrite the current data path in the metakernels')
+args = parser.parse_args()
+
+
+mks = glob(path.join(args.mk_path,'*.tm'))
+
+for mk in mks:
+    with open(mk, 'r') as f:
+        lines = f.readlines()
+
+    lines_to_change = [i for i,l in enumerate(lines) if 'PATH_VALUES     =' in l]
+    if not lines_to_change:
+        print(f'No path values in {mk}')
+
+    for i in lines_to_change:
+        lines[i] = f'      PATH_VALUES     = ( \'{args.new_data_path}\' )\n'
+
+    with open(mk, 'w') as f:
+        f.write(''.join(lines))


### PR DESCRIPTION
The simple brain-dead script that changes the data area variable in metakernels to point to an input directory. Pretty much assumes all instances of `PATH_VALUES =` are the kernel data area. 