### PR TITLE
Adds simple light time correction

### DIFF
--- a/ale/base/data_naif.py
+++ b/ale/base/data_naif.py
@@ -32,8 +32,9 @@ class NaifSpice():
         Returns the type of light time correciton and abberation correction to
         use in NAIF calls.
 
-        This defaults to no correction, concrete drivers should override this of
-        they need to use light time correction.
+        This defaults to light time correction and abberation correction (LT+S),
+        concrete drivers should override this if they need to either not use
+        light time correction or use a different type of light time correction.
 
         Returns
         -------
@@ -42,7 +43,7 @@ class NaifSpice():
           See https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/abcorr.html
           for the different options available.
         """
-        return 'NONE'
+        return 'LT+S'
 
     @property
     def odtx(self):

--- a/ale/base/data_naif.py
+++ b/ale/base/data_naif.py
@@ -27,6 +27,24 @@ class NaifSpice():
         pass
 
     @property
+    def light_time_correction(self):
+        """
+        Returns the type of light time correciton and abberation correction to
+        use in NAIF calls.
+
+        This defaults to no correction, concrete drivers should override this of
+        they need to use light time correction.
+
+        Returns
+        -------
+        : str
+          The light time and abberation correction string for use in NAIF calls.
+          See https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/abcorr.html
+          for the different options available.
+        """
+        return 'NONE'
+
+    @property
     def odtx(self):
         """
         Returns the x coefficient for the optical distortion model
@@ -254,7 +272,7 @@ class NaifSpice():
         sun_state, _ = spice.spkezr("SUN",
                                      self.center_ephemeris_time,
                                      self.reference_frame,
-                                     'NONE',
+                                     self.light_time_correction,
                                      self.target_name)
 
         return [sun_state[:4].tolist()], [sun_state[3:6].tolist()], [self.center_ephemeris_time]
@@ -283,7 +301,7 @@ class NaifSpice():
                 state, _ = spice.spkezr(self.spacecraft_name,
                                         time,
                                         self.reference_frame,
-                                        'NONE',
+                                        self.light_time_correction,
                                         self.target_name,)
                 pos.append(state[:3])
                 vel.append(state[3:])

--- a/ale/drivers/lro_drivers.py
+++ b/ale/drivers/lro_drivers.py
@@ -142,3 +142,22 @@ class LroLrocPds3LabelNaifSpiceDriver(NaifSpice, Pds3Label, LineScanner, Driver)
           Radial distortion coefficients. There is only one coefficient for LROC NAC l/r
         """
         return spice.gdpool('INS{}_OD_K'.format(self.ikid), 0, 1).tolist()
+
+    @property
+    def light_time_correction(self):
+        """
+        Returns the type of light time correciton and abberation correction to
+        use in NAIF calls.
+
+        LROC is specifically set to not use light time correction because it is
+        so close to the surface of the moon that light time correction to the
+        center of the body is incorrect.
+
+        Returns
+        -------
+        : str
+          The light time and abberation correction string for use in NAIF calls.
+          See https://naif.jpl.nasa.gov/pub/naif/toolkit_docs/C/req/abcorr.html
+          for the different options available.
+        """
+        return 'NONE'


### PR DESCRIPTION
Fixes #77 

This adds simple light time correction to the center of the body. For spacecraft like LRO and Kaguya, this may be significantly different from light time correction to the surface. ISIS has some [additional code](https://github.com/USGS-Astrogeology/ISIS3/blob/dev/isis/src/base/objs/Spice/SpacecraftPosition.cpp#L179) to do light time to surface instead. Should we implement that?