### PR TITLE
Fixed how the ephemeris start time and exposure duration are calculated for LRO

### DIFF
--- a/ale/drivers/lro_drivers.py
+++ b/ale/drivers/lro_drivers.py
@@ -137,3 +137,77 @@ class LroLrocPds3LabelNaifSpiceDriver(NaifSpice, Pds3Label, LineScanner, Driver)
           for the different options available.
         """
         return 'NONE'
+
+    @property
+    def ephemeris_start_time(self):
+        """
+        The starting ephemeris time for LRO is computed by taking the 
+        LRO:SPACECRAFT_CLOCK_PREROLL_COUNT, as defined in the label, and 
+        adding offsets that were taken from an IAK.
+        -------
+        : double
+          Starting ephemeris time of the image
+        """
+        start_time = spice.scs2e(self.spacecraft_id, self.label['LRO:SPACECRAFT_CLOCK_PREROLL_COUNT'])
+        return start_time + self.constant_time_offset + self.additional_preroll * self.exposure_duration
+
+    @property
+    def exposure_duration(self):
+        """
+        Takes the exposure_duration defined in a parent class and adds 
+        offsets taken from an IAK.
+
+         Returns
+         -------
+         : float
+           Returns the exposure duration in seconds.
+         """
+        return super().exposure_duration * (1 + self.multipli_line_error) + self.additive_line_error
+
+    @property
+    def multipli_line_error(self):
+        """
+        Returns the multiplicative line error defined in an IAK.
+
+         Returns
+         -------
+         : float
+           Returns the multiplicative line error.
+         """
+        return 0.0045
+
+    @property
+    def additive_line_error(self):
+        """
+        Returns the additive line error defined in an IAK.
+
+         Returns
+         -------
+         : float
+           Returns the additive line error.
+         """
+        return 0.0
+
+    @property
+    def constant_time_offset(self):
+        """
+        Returns the constant time offset defined in an IAK.
+
+         Returns
+         -------
+         : float
+           Returns the constant time offset.
+         """
+        return 0.0
+
+    @property
+    def additional_preroll(self):
+        """
+        Returns the addition preroll defined in an IAK.
+
+         Returns
+         -------
+         : float
+           Returns the additionl preroll.
+         """
+        return 1024.0

--- a/ale/drivers/lro_drivers.py
+++ b/ale/drivers/lro_drivers.py
@@ -162,10 +162,10 @@ class LroLrocPds3LabelNaifSpiceDriver(NaifSpice, Pds3Label, LineScanner, Driver)
          : float
            Returns the exposure duration in seconds.
          """
-        return super().exposure_duration * (1 + self.multipli_line_error) + self.additive_line_error
+        return super().exposure_duration * (1 + self.multiplicative_line_error) + self.additive_line_error
 
     @property
-    def multipli_line_error(self):
+    def multiplicative_line_error(self):
         """
         Returns the multiplicative line error defined in an IAK.
 

--- a/tests/pytests/test_lro_drivers.py
+++ b/tests/pytests/test_lro_drivers.py
@@ -54,3 +54,13 @@ def test_odtk(driver):
 def test_usgscsm_distortion_model(driver):
     distortion_model = driver.usgscsm_distortion_model
     assert distortion_model['lrolrocnac']['coefficients'] == [1.0]
+
+@patch('ale.base.label_pds3.Pds3Label.instrument_host_id', 'LRO')
+@patch('ale.drivers.lro_drivers.LroLrocPds3LabelNaifSpiceDriver.exposure_duration', 1)
+def test_ephemeris_start_time(driver):
+    with patch.dict(driver.label, {'LRO:SPACECRAFT_CLOCK_PREROLL_COUNT':'1'}) as f:
+        assert driver.ephemeris_start_time == 1024.1
+
+@patch('ale.base.label_pds3.Pds3Label.exposure_duration', 1)
+def test_exposure_duration(driver):
+    assert driver.exposure_duration == 1.0045


### PR DESCRIPTION
The values used for the offsets were taken from an IAK and needed to be hardcoded. The equations for these calculations were taken from the LroNarrowAngleCamera class in ISIS. I added in the offsets that are 0 to make sure our equations match ISIS's and it is clear what we are doing.