### PR TITLE
Added code to account for ISIS ccd center

### DIFF
--- a/ale/drivers/dawn_drivers.py
+++ b/ale/drivers/dawn_drivers.py
@@ -216,12 +216,17 @@ class DawnFcPds3NaifSpiceDriver(Pds3Label, NaifSpice, Framer, Driver):
         Returns center detector sample acquired from Spice Kernels.
         Expects ikid to be defined. This should be the integer Naid ID code for
         the instrument.
+
+        We have to add 0.5 to the CCD Center because the Dawn IK defines the
+        detector pixels as 0.0 being the center of the first pixel so they are
+        -0.5 based.
+
         Returns
         -------
         : float
           center detector sample
         """
-        return float(spice.gdpool('INS{}_CCD_CENTER'.format(self.ikid), 0, 2)[0])
+        return float(spice.gdpool('INS{}_CCD_CENTER'.format(self.ikid), 0, 2)[0]) + 0.5
 
     @property
     def detector_center_line(self):
@@ -229,9 +234,14 @@ class DawnFcPds3NaifSpiceDriver(Pds3Label, NaifSpice, Framer, Driver):
         Returns center detector line acquired from Spice Kernels.
         Expects ikid to be defined. This should be the integer Naid ID code for
         the instrument.
+
+        We have to add 0.5 to the CCD Center because the Dawn IK defines the
+        detector pixels as 0.0 being the center of the first pixel so they are
+        -0.5 based.
+
         Returns
         -------
         : float
           center detector line
         """
-        return float(spice.gdpool('INS{}_CCD_CENTER'.format(self.ikid), 0, 2)[1])
+        return float(spice.gdpool('INS{}_CCD_CENTER'.format(self.ikid), 0, 2)[1]) + 0.5

--- a/ale/drivers/kaguya_drivers.py
+++ b/ale/drivers/kaguya_drivers.py
@@ -232,13 +232,15 @@ class KaguyaTcPds3NaifSpiceDriver(Pds3Label,NaifSpice, LineScanner, Driver):
         Returnce the center detector sample of the image. Expects tc_id to be
         defined. This should be a string of the form LISM_TC1 or LISM_TC2.
 
+        We subtract 0.5 from the ISIS center line because ISIS detector
+        coordinates are 0.5 based.
+
         Returns
         -------
         : int
           The detector sample of the principle point
         """
-        # Pixels are 0 based, not one based, so subtract 1
-        return spice.gdpool('INS{}_CENTER'.format(self.ikid), 0, 2)[0]-1
+        return spice.gdpool('INS{}_CENTER'.format(self.ikid), 0, 2)[0] - 0.5
 
     @property
     def _sensor_orientation(self):

--- a/ale/drivers/lro_drivers.py
+++ b/ale/drivers/lro_drivers.py
@@ -137,3 +137,16 @@ class LroLrocPds3LabelNaifSpiceDriver(NaifSpice, Pds3Label, LineScanner, Driver)
           for the different options available.
         """
         return 'NONE'
+
+    @property
+    def detector_center_sample(self):
+        """
+        The center of the CCD in detector pixels
+        ISIS uses 0.5 based CCD samples, so we need to convert to 0 based.
+
+        Returns
+        -------
+        float :
+            The center sample of the CCD
+        """
+        return super().detector_center_sample - 0.5

--- a/ale/drivers/messenger_drivers.py
+++ b/ale/drivers/messenger_drivers.py
@@ -151,12 +151,15 @@ class MessengerMdisPds3NaifSpiceDriver(Pds3Label, NaifSpice, Framer, Driver):
         Expects ikid to be defined. This should be the integer Naid ID code for
         the instrument.
 
+        We subtract 0.5 from the ISIS center sample because ISIS detector
+        coordinates are 0.5 based.
+
         Returns
         -------
         : float
           center detector sample
         """
-        return float(spice.gdpool('INS{}_BORESIGHT'.format(self.ikid), 0, 3)[0])
+        return float(spice.gdpool('INS{}_BORESIGHT'.format(self.ikid), 0, 3)[0]) - 0.5
 
     @property
     def detector_center_line(self):
@@ -165,12 +168,15 @@ class MessengerMdisPds3NaifSpiceDriver(Pds3Label, NaifSpice, Framer, Driver):
         Expects ikid to be defined. This should be the integer Naid ID code for
         the instrument.
 
+        We subtract 0.5 from the ISIS center line because ISIS detector
+        coordinates are 0.5 based.
+
         Returns
         -------
         : float
           center detector line
         """
-        return float(spice.gdpool('INS{}_BORESIGHT'.format(self.ikid), 0, 3)[1])
+        return float(spice.gdpool('INS{}_BORESIGHT'.format(self.ikid), 0, 3)[1]) - 0.5
 
     @property
     def sensor_model_version(self):
@@ -359,12 +365,15 @@ class MessengerMdisIsisLabelNaifSpiceDriver(IsisLabel, NaifSpice, Framer, Driver
         Expects ikid to be defined. This should be the integer Naid ID code for
         the instrument.
 
+        We subtract 0.5 from the ISIS center sample because ISIS detector
+        coordinates are 0.5 based.
+
         Returns
         -------
         : float
           detector center sample
         """
-        return float(spice.gdpool('INS{}_BORESIGHT'.format(self.ikid), 0, 3)[0])
+        return float(spice.gdpool('INS{}_BORESIGHT'.format(self.ikid), 0, 3)[0]) - 0.5
 
 
     @property
@@ -374,12 +383,15 @@ class MessengerMdisIsisLabelNaifSpiceDriver(IsisLabel, NaifSpice, Framer, Driver
         Expects ikid to be defined. This should be the integer Naid ID code for
         the instrument.
 
+        We subtract 0.5 from the ISIS center line because ISIS detector
+        coordinates are 0.5 based.
+
         Returns
         -------
         : float
           detector center line
         """
-        return float(spice.gdpool('INS{}_BORESIGHT'.format(self.ikid), 0, 3)[1])
+        return float(spice.gdpool('INS{}_BORESIGHT'.format(self.ikid), 0, 3)[1]) - 0.5
 
     @property
     def sensor_model_version(self):

--- a/ale/drivers/mex_drivers.py
+++ b/ale/drivers/mex_drivers.py
@@ -289,7 +289,7 @@ class MexHrscPds3NaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, RadialDistor
         """
         Returns the center detector line.
 
-        For HRSC, we are dealing with a single line, so center line will be 1.
+        For HRSC, we are dealing with a single line, so center line will be 0.
 
         Returns
         -------
@@ -297,7 +297,6 @@ class MexHrscPds3NaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, RadialDistor
           Detector line of the principal point
         """
         return 0.0
-
 
     @property
     def detector_start_sample(self):
@@ -315,14 +314,16 @@ class MexHrscPds3NaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, RadialDistor
         """
         Returns the center detector sample.
 
-        For HRSC, center sample is consistent regardless of filter.
+        For HRSC, center sample is consistent regardless of filter. This is
+        different from ISIS's center sample because ISIS line scan sensors use
+        0.5 based detector samples.
 
         Returns
         -------
         : float
           Detector sample of the principal point
         """
-        return 2592.5
+        return 2592.0
 
 
     @property

--- a/ale/drivers/mro_drivers.py
+++ b/ale/drivers/mro_drivers.py
@@ -179,6 +179,19 @@ class MroCtxIsisLabelNaifSpiceDriver(IsisLabel, NaifSpice, LineScanner, RadialDi
         return self.label['IsisCube']['Instrument']['SampleFirstPixel']
 
     @property
+    def detector_center_sample(self):
+        """
+        The center of the CCD in detector pixels
+        ISIS uses 0.5 based CCD samples, so we need to convert to 0 based.
+
+        Returns
+        -------
+        float :
+            The center sample of the CCD
+        """
+        return super().detector_center_sample - 0.5
+
+    @property
     def sensor_model_version(self):
         """
         Returns
@@ -261,6 +274,19 @@ class MroCtxPds3LabelNaifSpiceDriver(Pds3Label, NaifSpice, LineScanner, RadialDi
           Starting detector sample for the image
         """
         return self.label.get('SAMPLE_FIRST_PIXEL', 0)
+
+    @property
+    def detector_center_sample(self):
+        """
+        The center of the CCD in detector pixels
+        ISIS uses 0.5 based CCD samples, so we need to convert to 0 based.
+
+        Returns
+        -------
+        float :
+            The center sample of the CCD
+        """
+        return super().detector_center_sample - 0.5
 
     @property
     def sensor_model_version(self):

--- a/ale/drivers/mro_drivers.py
+++ b/ale/drivers/mro_drivers.py
@@ -61,6 +61,19 @@ class MroCtxIsisLabelIsisSpiceDriver(Driver, IsisSpice, LineScanner, RadialDisto
         """
         return self.label["IsisCube"]["Instrument"]["LineExposureDuration"].value * 0.001 # Scale to seconds
 
+    @property
+    def detector_center_sample(self):
+        """
+        The center of the CCD in detector pixels
+        ISIS uses 0.5 based CCD samples, so we need to convert to 0 based.
+
+        Returns
+        -------
+        float :
+            The center sample of the CCD
+        """
+        return super().detector_center_sample - 0.5
+
 class MroCtxIsisLabelNaifSpiceDriver(IsisLabel, NaifSpice, LineScanner, RadialDistortion, Driver):
     """
     Driver for reading CTX ISIS labels.

--- a/tests/pytests/test_kaguya_drivers.py
+++ b/tests/pytests/test_kaguya_drivers.py
@@ -60,7 +60,7 @@ def test_detector_center_line(driver):
 
 @patch('ale.base.label_pds3.Pds3Label.instrument_id', 123)
 def test_detector_center_sample(driver):
-    assert driver.detector_center_sample == 0
+    assert driver.detector_center_sample == 0.5
 
 @patch('ale.base.label_pds3.Pds3Label.instrument_id', 123)
 @patch('ale.base.label_pds3.Pds3Label.target_name', 'MOON')

--- a/tests/pytests/test_mdis_drivers.py
+++ b/tests/pytests/test_mdis_drivers.py
@@ -42,7 +42,7 @@ def test_instrument_id_pds3(Pds3Driver):
         mock_id.return_value = 'MDIS-WAC'
         assert Pds3Driver.instrument_id == 'MSGR_MDIS_WAC'
         mock_id.return_value = 'MDIS-NAC'
-        assert Pds3Driver.instrument_id == 'MSGR_MDIS_NAC'    
+        assert Pds3Driver.instrument_id == 'MSGR_MDIS_NAC'
 
 @patch('ale.base.label_pds3.Pds3Label.filter_number', 10)
 @patch('ale.base.data_naif.NaifSpice.ikid', 100)
@@ -61,11 +61,11 @@ def test_detector_start_line_pds3(Pds3Driver):
 
 @patch('ale.base.data_naif.NaifSpice.ikid', 123)
 def test_detector_center_sample_pds3(Pds3Driver):
-    assert Pds3Driver.detector_center_sample == 1
+    assert Pds3Driver.detector_center_sample == 0.5
 
 @patch('ale.base.data_naif.NaifSpice.ikid', 123)
 def test_detector_center_line_pds3(Pds3Driver):
-    assert Pds3Driver.detector_center_line == 1
+    assert Pds3Driver.detector_center_line == 0.5
 
 def test_sensor_model_version_pds3(Pds3Driver):
     assert Pds3Driver.sensor_model_version == 2
@@ -115,11 +115,11 @@ def test_detector_start_line_isis(IsisLabelDriver):
 
 @patch('ale.base.data_naif.NaifSpice.ikid', 100)
 def test_detector_center_line_isis(IsisLabelDriver):
-    assert IsisLabelDriver.detector_center_line == 1
+    assert IsisLabelDriver.detector_center_line == 0.5
 
 @patch('ale.base.data_naif.NaifSpice.ikid', 100)
 def detector_center_sample_isis(IsisLabelDriver):
-    assert IsisLabelDriver.detector_center_sample == 1
+    assert IsisLabelDriver.detector_center_sample == 0.5
 
 def test_sensor_model_version_isis(IsisLabelDriver):
     assert IsisLabelDriver.sensor_model_version == 2


### PR DESCRIPTION
ISIS uses 0.5 based detector pixels so all the drivers that use the '_BORESIGHT` keywords need to subtract 0.5 to convert to 0 based detector pixels. The exception is that line scan instruments use 0 based detector lines. The drivers that use the `CCD_CENTER` keywords need to account for whatever is defined in the kernels. For example Dawn FC has -0.5 based Detector coordinates.