### PR TITLE
Updated Kaguya CCD Center

### DIFF
--- a/ale/drivers/kaguya_drivers.py
+++ b/ale/drivers/kaguya_drivers.py
@@ -219,21 +219,27 @@ class KaguyaTcPds3NaifSpiceDriver(Pds3Label,NaifSpice, LineScanner, Driver):
     @property
     def detector_center_line(self):
         """
+        Returns the center detector line of the detector. Expects tc_id to be
+        defined. This should be a string of the form LISM_TC1 or LISM_TC2.
+
+        We subtract 0.5 from the center line because as per the IK:
+        Center of the first pixel is defined as "1.0".
+
         Returns
         -------
         : int
           The detector line of the principle point
         """
-        return 0
+        return spice.gdpool('INS{}_CENTER'.format(self.ikid), 0, 2)[0] - 0.5
 
     @property
     def detector_center_sample(self):
         """
-        Returnce the center detector sample of the image. Expects tc_id to be
+        Returns the center detector sample of the detector. Expects tc_id to be
         defined. This should be a string of the form LISM_TC1 or LISM_TC2.
 
-        We subtract 0.5 from the ISIS center line because ISIS detector
-        coordinates are 0.5 based.
+        We subtract 0.5 from the center sample because as per the IK:
+        Center of the first pixel is defined as "1.0".
 
         Returns
         -------

--- a/tests/pytests/test_kaguya_drivers.py
+++ b/tests/pytests/test_kaguya_drivers.py
@@ -55,8 +55,9 @@ def test_ephemeris_start_time(driver):
                                    pvl._collections.Units(value=501, units='<sec>')}) as f:
         assert driver.ephemeris_start_time == 0.1
 
+@patch('ale.base.label_pds3.Pds3Label.instrument_id', 123)
 def test_detector_center_line(driver):
-    assert driver.detector_center_line == 0
+    assert driver.detector_center_line == 0.5
 
 @patch('ale.base.label_pds3.Pds3Label.instrument_id', 123)
 def test_detector_center_sample(driver):


### PR DESCRIPTION
Sorry, I noticed that while double checking stuff in #231 
Here's the relevant bit from the IK

```
Detector CCD Parameters
---------------------------------------------------------------------------

   The following table summarizes TC individual camera detector 
   parameters. As these data show the detectors are all line arrays.


      -----------------------------------------------------------------
             parameter                     TC1             TC2
      -----------------------------------------------------------------
      Pixel Size, microns
          Cross-track                      7.0              7.0
          Along-track                      7.0              7.0
      Detector Array Size
          Cross-track                      4096             4096
          Along-track                      1                1
      Detector Array Center (*1)
          Cross-track                      2048.5           2048.5
          Along-track                      1.0              1.0
      -----------------------------------------------------------------

    (*1) Center of the first pixel is defined as "1.0".


   These values are incorporated in the keywords below; pixel sizes 
   are converted to MILLIMETERS.
                    ^^^^^^^^^^^

      \begindata

      INS-131351_PIXEL_SAMPLES  = ( 4096        )
      INS-131351_PIXEL_LINES    = ( 1           )
      INS-131351_CENTER         = ( 2048.5, 1.0 )       
      INS-131351_PIXEL_SIZE     = ( 0.007    )

      INS-131371_PIXEL_SAMPLES  = ( 4096        )
      INS-131371_PIXEL_LINES    = ( 1           )
      INS-131371_CENTER         = ( 2048.5, 1.0 )       
      INS-131371_PIXEL_SIZE     = ( 0.007    )

      \begintext
```