### PR TITLE
Updated mix-in order so that sensor type is first

### DIFF
--- a/ale/drivers/cassini_drivers.py
+++ b/ale/drivers/cassini_drivers.py
@@ -19,7 +19,7 @@ from ale.transformation import FrameChain
 from scipy.spatial.transform import Rotation
 
 
-class CassiniIssPds3LabelNaifSpiceDriver(Pds3Label, NaifSpice, Framer, RadialDistortion, Driver):
+class CassiniIssPds3LabelNaifSpiceDriver(Framer, Pds3Label, NaifSpice, RadialDistortion, Driver):
     """
     Cassini mixin class for defining Spice calls.
     """
@@ -296,4 +296,3 @@ class CassiniIssPds3LabelNaifSpiceDriver(Pds3Label, NaifSpice, Framer, RadialDis
           return 14082360
         elif self.instrument_id == "CASSINI_ISS_WAC":
           return self._original_naif_sensor_frame_id
-

--- a/ale/drivers/dawn_drivers.py
+++ b/ale/drivers/dawn_drivers.py
@@ -11,7 +11,7 @@ from ale.base.data_naif import NaifSpice
 from ale.base.label_pds3 import Pds3Label
 from ale.base.type_sensor import Framer
 
-class DawnFcPds3NaifSpiceDriver(Pds3Label, NaifSpice, Framer, Driver):
+class DawnFcPds3NaifSpiceDriver(Framer, Pds3Label, NaifSpice, Driver):
     """
     Dawn driver for generating an ISD from a Dawn PDS3 image.
     """

--- a/ale/drivers/isis_ideal_drivers.py
+++ b/ale/drivers/isis_ideal_drivers.py
@@ -5,7 +5,7 @@ from ale.base.type_sensor import LineScanner
 from ale.base.type_distortion import NoDistortion
 
 
-class IdealLsIsisLabelIsisSpiceDriver(IsisSpice, LineScanner, IsisLabel, NoDistortion, Driver):
+class IdealLsIsisLabelIsisSpiceDriver(LineScanner, IsisSpice, IsisLabel, NoDistortion, Driver):
     @property
     def sensor_name(self):
         """

--- a/ale/drivers/kaguya_drivers.py
+++ b/ale/drivers/kaguya_drivers.py
@@ -9,7 +9,7 @@ from ale.base.label_pds3 import Pds3Label
 from ale.base.type_sensor import LineScanner
 
 
-class KaguyaTcPds3NaifSpiceDriver(Pds3Label,NaifSpice, LineScanner, Driver):
+class KaguyaTcPds3NaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, Driver):
     """
     Driver for a PDS3 Kaguya Terrain Camera (TC) images. Specifically level2b0 mono and stereo images.
 

--- a/ale/drivers/lro_drivers.py
+++ b/ale/drivers/lro_drivers.py
@@ -12,7 +12,7 @@ from ale.base.label_pds3 import Pds3Label
 from ale.base.type_sensor import LineScanner
 
 
-class LroLrocPds3LabelNaifSpiceDriver(NaifSpice, Pds3Label, LineScanner, Driver):
+class LroLrocPds3LabelNaifSpiceDriver(LineScanner, NaifSpice, Pds3Label, Driver):
     """
     Driver for reading LROC NACL, NACR (not WAC, it is a push frame) labels. Requires a Spice mixin to
     acquire addtional ephemeris and instrument data located exclusively in SPICE kernels, A PDS3 label,

--- a/ale/drivers/messenger_drivers.py
+++ b/ale/drivers/messenger_drivers.py
@@ -17,7 +17,7 @@ ID_LOOKUP = {
     'MDIS-NAC':'MSGR_MDIS_NAC',
 }
 
-class MessengerMdisPds3NaifSpiceDriver(Pds3Label, NaifSpice, Framer, Driver):
+class MessengerMdisPds3NaifSpiceDriver(Framer, Pds3Label, NaifSpice, Driver):
     """
     Driver for reading MDIS PDS3 labels. Requires a Spice mixin to acquire addtional
     ephemeris and instrument data located exclusively in spice kernels.
@@ -92,15 +92,15 @@ class MessengerMdisPds3NaifSpiceDriver(Pds3Label, NaifSpice, Framer, Driver):
           instrument id
         """
         return ID_LOOKUP[super().instrument_id]
-        
+
     @property
     def sampling_factor(self):
         """
         Returns the summing factor from the PDS3 label. For example a return value of 2
         indicates that 2 lines and 2 samples (4 pixels) were summed and divided by 4
         to produce the output pixel value.
-        
-        NOTE: This is overwritten for the messenger driver as the value is stored in "MESS:PIXELBIN" 
+
+        NOTE: This is overwritten for the messenger driver as the value is stored in "MESS:PIXELBIN"
 
         Returns
         -------
@@ -169,8 +169,8 @@ class MessengerMdisPds3NaifSpiceDriver(Pds3Label, NaifSpice, Framer, Driver):
         Returns center detector sample acquired from Spice Kernels.
         Expects ikid to be defined. This should be the integer Naid ID code for
         the instrument.
-        
-        NOTE: This value is defined in an ISIS iak as 512.5, but we subtract 0.5 from the 
+
+        NOTE: This value is defined in an ISIS iak as 512.5, but we subtract 0.5 from the
         ISIS center sample because ISIS detector coordinates are 0.5 based.
 
         Returns
@@ -186,8 +186,8 @@ class MessengerMdisPds3NaifSpiceDriver(Pds3Label, NaifSpice, Framer, Driver):
         Returns center detector line acquired from Spice Kernels.
         Expects ikid to be defined. This should be the integer Naid ID code for
         the instrument.
-        
-        NOTE: This value is defined in an ISIS iak as 512.5, but we subtract 0.5 from the 
+
+        NOTE: This value is defined in an ISIS iak as 512.5, but we subtract 0.5 from the
         ISIS center sample because ISIS detector coordinates are 0.5 based.
 
         Returns

--- a/ale/drivers/mro_drivers.py
+++ b/ale/drivers/mro_drivers.py
@@ -15,7 +15,7 @@ from ale.base.type_distortion import RadialDistortion
 from ale.base.type_sensor import LineScanner
 
 
-class MroCtxIsisLabelIsisSpiceDriver(IsisLabel, IsisSpice, LineScanner, RadialDistortion, Driver):
+class MroCtxIsisLabelIsisSpiceDriver(LineScanner, IsisLabel, IsisSpice, RadialDistortion, Driver):
 
     @property
     def instrument_id(self):


### PR DESCRIPTION
There is a conflict between data_isis and the sensor type mix-ins for the epehemeris_stop_time property. Changed all of the mix-in order so that the type comes before the data to avoid getting the wrong one.