### PR TITLE
IsisSpice now fails when it cannot find tables

### DIFF
--- a/ale/base/data_isis.py
+++ b/ale/base/data_isis.py
@@ -205,7 +205,7 @@ class IsisSpice():
                     binary_data = read_table_data(table, self._file)
                     self._inst_pointing_table = parse_table(table, binary_data)
                     return self._inst_pointing_table
-            raise Exception(f'Could not find InstrumentPointing table on file {self._file}')
+            raise ValueError(f'Could not find InstrumentPointing table on file {self._file}')
         return self._inst_pointing_table
 
     @property
@@ -225,7 +225,7 @@ class IsisSpice():
                     binary_data = read_table_data(table, self._file)
                     self._body_orientation_table = parse_table(table, binary_data)
                     return self._body_orientation_table
-            raise Exception(f'Could not find BodyRotation table on file {self._file}')
+            raise ValueError(f'Could not find BodyRotation table on file {self._file}')
         return self._body_orientation_table
 
     @property
@@ -245,7 +245,7 @@ class IsisSpice():
                     binary_data = read_table_data(table, self._file)
                     self._inst_position_table = parse_table(table, binary_data)
                     return self._inst_position_table
-            raise Exception(f'Could not find InstrumentPosition table on file {self._file}')
+            raise ValueError(f'Could not find InstrumentPosition table on file {self._file}')
         return self._inst_position_table
 
     @property
@@ -265,7 +265,7 @@ class IsisSpice():
                     binary_data = read_table_data(table, self._file)
                     self._sun_position_table = parse_table(table, binary_data)
                     return self._sun_position_table
-            raise Exception(f'Could not find SunPosition table on file {self._file}')
+            raise ValueError(f'Could not find SunPosition table on file {self._file}')
         return self._sun_position_table
 
     def __enter__(self):

--- a/ale/base/data_isis.py
+++ b/ale/base/data_isis.py
@@ -204,6 +204,8 @@ class IsisSpice():
                 if table['Name'] == 'InstrumentPointing':
                     binary_data = read_table_data(table, self._file)
                     self._inst_pointing_table = parse_table(table, binary_data)
+                    return self._inst_pointing_table
+            raise Exception(f'Could not find InstrumentPointing table on file {self._file}')
         return self._inst_pointing_table
 
     @property
@@ -222,6 +224,8 @@ class IsisSpice():
                 if table['Name'] == 'BodyRotation':
                     binary_data = read_table_data(table, self._file)
                     self._body_orientation_table = parse_table(table, binary_data)
+                    return self._body_orientation_table
+            raise Exception(f'Could not find BodyRotation table on file {self._file}')
         return self._body_orientation_table
 
     @property
@@ -240,6 +244,8 @@ class IsisSpice():
                 if table['Name'] == 'InstrumentPosition':
                     binary_data = read_table_data(table, self._file)
                     self._inst_position_table = parse_table(table, binary_data)
+                    return self._inst_position_table
+            raise Exception(f'Could not find InstrumentPosition table on file {self._file}')
         return self._inst_position_table
 
     @property
@@ -258,6 +264,8 @@ class IsisSpice():
                 if table['Name'] == 'SunPosition':
                     binary_data = read_table_data(table, self._file)
                     self._sun_position_table = parse_table(table, binary_data)
+                    return self._sun_position_table
+            raise Exception(f'Could not find SunPosition table on file {self._file}')
         return self._sun_position_table
 
     def __enter__(self):

--- a/tests/pytests/test_data_isis.py
+++ b/tests/pytests/test_data_isis.py
@@ -706,11 +706,11 @@ def test_no_tables():
     test_mix_in = IsisSpice()
     test_mix_in._file = test_file
     test_mix_in.label = pvl.load(test_file)
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         test_mix_in.inst_pointing_table
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         test_mix_in.body_orientation_table
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         test_mix_in.inst_position_table
-    with pytest.raises(Exception):
+    with pytest.raises(ValueError):
         test_mix_in.sun_position_table

--- a/tests/pytests/test_data_isis.py
+++ b/tests/pytests/test_data_isis.py
@@ -4,6 +4,7 @@ import pvl
 import numpy as np
 from ale.base.data_isis import IsisSpice
 
+from conftest import get_image_label
 
 testlabel = """
 Object = IsisCube
@@ -699,3 +700,17 @@ def test_inst_position_cache(testdata):
                                    [[-1000, -2000*np.pi*np.sqrt(3)/9, 2000*np.pi*np.sqrt(3)/9],
                                     [-2000*np.pi*np.sqrt(3)/9, 2000*np.pi*np.sqrt(3)/9, -1000]])
     np.testing.assert_equal(sensor_times, [0, 1])
+
+def test_no_tables():
+    test_file = get_image_label('B10_013341_1010_XN_79S172W')
+    test_mix_in = IsisSpice()
+    test_mix_in._file = test_file
+    test_mix_in.label = pvl.load(test_file)
+    with pytest.raises(Exception):
+        test_mix_in.inst_pointing_table
+    with pytest.raises(Exception):
+        test_mix_in.body_orientation_table
+    with pytest.raises(Exception):
+        test_mix_in.inst_position_table
+    with pytest.raises(Exception):
+        test_mix_in.sun_position_table


### PR DESCRIPTION
This should cause load to function properly with cubes that don't have attached SPICE data.