### PR TITLE
Spiceinit Fixes

### DIFF
--- a/ale/base/data_naif.py
+++ b/ale/base/data_naif.py
@@ -295,14 +295,20 @@ class NaifSpice():
         : (sun_positions, sun_velocities)
           a tuple containing a list of sun positions, a list of sun velocities
         """
-        sun_state, _ = spice.spkezr("SUN",
-                                     self.center_ephemeris_time,
-                                     self.reference_frame,
-                                     'LT+S',
-                                     self.target_name)
-        positions = 1000 * np.asarray([sun_state[:3]])
-        velocities = 1000 * np.asarray([sun_state[3:6]])
-        times = np.asarray([self.center_ephemeris_time])
+        times = [self.center_ephemeris_time]
+        positions = []
+        velocities = []
+
+        for time in times:
+            sun_state, _ = spice.spkezr("SUN",
+                                         time,
+                                         self.reference_frame,
+                                         'LT+S',
+                                         self.target_name)
+            positions.append(sun_state[:3])
+            velocities.append(sun_state[3:6])
+        positions = 1000 * np.asarray(positions)
+        velocities = 1000 * np.asarray(velocities)
 
         return positions, velocities, times
 
@@ -367,7 +373,7 @@ class NaifSpice():
                                             self.reference_frame,
                                             self.light_time_correction,
                                             observer)
-       
+
                 if self.swap_observer_target:
                     pos.append(-state[:3])
                     vel.append(-state[3:])
@@ -526,4 +532,3 @@ class NaifSpice():
             self._naif_keywords = {**self._naif_keywords, **util.query_kernel_pool(f"*{self.ikid}*"),  **util.query_kernel_pool(f"*{self.target_id}*")}
 
         return self._naif_keywords
-

--- a/ale/drivers/__init__.py
+++ b/ale/drivers/__init__.py
@@ -28,7 +28,7 @@ __formatters__ = {'usgscsm': to_usgscsm,
                   'isis': to_isis}
 
 def sort_drivers(drivers=[]):
-    return list(sorted(drivers, key=lambda x:IsisSpice in x.__bases__, reverse=True))
+    return list(sorted(drivers, key=lambda x:IsisSpice in x.__bases__, reverse=False))
 
 class AleJsonEncoder(json.JSONEncoder):
     def default(self, obj):

--- a/ale/drivers/dawn_drivers.py
+++ b/ale/drivers/dawn_drivers.py
@@ -10,6 +10,11 @@ from ale.base.data_naif import NaifSpice
 from ale.base.label_pds3 import Pds3Label
 from ale.base.type_sensor import Framer
 
+ID_LOOKUP = {
+    "FC1" : "DAWN_FC1",
+    "FC2" : "DAWN_FC2"
+}
+
 class DawnFcPds3NaifSpiceDriver(Framer, Pds3Label, NaifSpice, Driver):
     """
     Dawn driver for generating an ISD from a Dawn PDS3 image.
@@ -32,7 +37,7 @@ class DawnFcPds3NaifSpiceDriver(Framer, Pds3Label, NaifSpice, Driver):
         instrument_id = super().instrument_id
         filter_number = self.filter_number
 
-        return "DAWN_{}_FILTER_{}".format(instrument_id, filter_number)
+        return "{}_FILTER_{}".format(ID_LOOKUP[instrument_id], filter_number)
 
     @property
     def label(self):

--- a/tests/pytests/test_load.py
+++ b/tests/pytests/test_load.py
@@ -22,7 +22,7 @@ def mess_kernels():
 def test_priority(tmpdir, monkeypatch):
     drivers = [type('FooNaifSpice', (NaifSpice,), {}), type('BarIsisSpice', (IsisSpice,), {}), type('BazNaifSpice', (NaifSpice,), {}), type('FubarIsisSpice', (IsisSpice,), {})]
     sorted_drivers = sort_drivers(drivers)
-    assert all([IsisSpice in klass.__bases__ for klass in sorted_drivers[:2]])
+    assert all([IsisSpice in klass.__bases__ for klass in sorted_drivers[2:]])
 
 def test_mess_load(mess_kernels):
     updated_kernels = mess_kernels


### PR DESCRIPTION
Changes the driver sort to return IsisLabelNaifSpice drivers before IsisLabelIsisSpice drivers. 

Also adds a lookup table to the dawn drivers to prevent them from succeeding on the wrong image types.