### PR TITLE
Added av to ISIS table rotations

### DIFF
--- a/ale/transformation.py
+++ b/ale/transformation.py
@@ -35,10 +35,17 @@ def create_rotations(rotation_table):
                           rotation_table['J2000Q2'],
                           rotation_table['J2000Q3'],
                           rotation_table['J2000Q0']]).T
+        if 'AV1' in rotation_table:
+            av = np.array([rotation_table['AV1'],
+                           rotation_table['AV2'],
+                           rotation_table['AV3']]).T
+        else:
+            av = None
         time_dep_rot = TimeDependentRotation(quats,
                                              rotation_table['ET'],
                                              root_frame,
-                                             last_time_dep_frame)
+                                             last_time_dep_frame,
+                                             av=av)
         rotations.append(time_dep_rot)
     # Case 2: It's a table of Euler angle coefficients
     elif 'J2000Ang1' in rotation_table:

--- a/tests/pytests/test_transformation.py
+++ b/tests/pytests/test_transformation.py
@@ -16,8 +16,27 @@ def test_create_quaternion_rotations():
     assert len(rotations) == 1
     assert rotations[0].source == 1
     assert rotations[0].dest == -1000
-    np.testing.assert_equal(rotations[0].times, np.array([0, 1]))
-    np.testing.assert_almost_equal(rotations[0].quats, np.array([[0, 0, 0, 1], [0.5, 0.5, 0.5, 0.5]]))
+    np.testing.assert_equal(rotations[0].times, [0, 1])
+    np.testing.assert_almost_equal(rotations[0].quats, [[0, 0, 0, 1], [0.5, 0.5, 0.5, 0.5]])
+
+def test_create_quaternion_av_rotations():
+    test_table = {
+        'J2000Q0' : [1, 0.5],
+        'J2000Q1' : [0, 0.5],
+        'J2000Q2' : [0, 0.5],
+        'J2000Q3' : [0, 0.5],
+        'AV1' : [0, 1],
+        'AV2' : [2, 3],
+        'AV3' :[4, 5],
+        'ET' : [0, 1],
+        'TimeDependentFrames' : [-1000, -100, 1]}
+    rotations = create_rotations(test_table)
+    assert len(rotations) == 1
+    assert rotations[0].source == 1
+    assert rotations[0].dest == -1000
+    np.testing.assert_equal(rotations[0].times, [0, 1])
+    np.testing.assert_almost_equal(rotations[0].quats, [[0, 0, 0, 1], [0.5, 0.5, 0.5, 0.5]])
+    np.testing.assert_almost_equal(rotations[0].av, [[0, 2, 4], [1, 3, 5]])
 
 def test_create_two_rotations():
     test_table = {


### PR DESCRIPTION
When AV was added to rotations, the code that creates rotations from ISIS rotation tables wasn't updated to read the AV.

This fixes that. Tests with a HiRISE cube before this change showed incorrect sensor velocities. After this change, everything lines up as expected.