### PR TITLE
Removed subwindowing code from MDIS drivers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # Specify the required version of CMake.
 # cmake 3.10 required for ctest/gtest integration
 cmake_minimum_required(VERSION 3.10)
-project(ale VERSION 0.6.0 DESCRIPTION "Abstraction Library for Ephemerides ")
+project(ale VERSION 0.6.2 DESCRIPTION "Abstraction Library for Ephemerides ")
 
 # include what we need
 include(GNUInstallDirs)

--- a/ale/drivers/mess_drivers.py
+++ b/ale/drivers/mess_drivers.py
@@ -174,34 +174,6 @@ class MessengerMdisPds3NaifSpiceDriver(Framer, Pds3Label, NaifSpice, Driver):
         return f_t(self.label['FOCAL_PLANE_TEMPERATURE'].value)
 
     @property
-    def detector_start_sample(self):
-        """
-        Returns starting detector sample quired from Spice Kernels.
-        Expects ikid to be defined. This should be the integer Naid ID code for
-        the instrument.
-
-        Returns
-        -------
-        : int
-          starting detector sample
-        """
-        return int(spice.gdpool('INS{}_FPUBIN_START_SAMPLE'.format(self.ikid), 0, 1)[0])
-
-    @property
-    def detector_start_line(self):
-        """
-        Returns starting detector line acquired from Spice Kernels.
-        Expects ikid to be defined. This should be the integer Naid ID code for
-        the instrument.
-
-        Returns
-        -------
-        : int
-          starting detector line
-        """
-        return int(spice.gdpool('INS{}_FPUBIN_START_LINE'.format(self.ikid), 0, 1)[0])
-
-    @property
     def detector_center_sample(self):
         """
         Returns center detector sample acquired from Spice Kernels.
@@ -395,34 +367,6 @@ class MessengerMdisIsisLabelNaifSpiceDriver(IsisLabel, NaifSpice, Framer, Driver
 
         # eval at the focal_plane_temperature
         return f_t(self.label['IsisCube']['Instrument']['FocalPlaneTemperature'].value)
-
-    @property
-    def detector_start_sample(self):
-        """
-        Returns starting detector sample quired from Spice Kernels.
-        Expects ikid to be defined. This should be the integer Naid ID code for
-        the instrument.
-
-        Returns
-        -------
-        : int
-          starting detector sample
-        """
-        return int(spice.gdpool('INS{}_FPUBIN_START_SAMPLE'.format(self.ikid), 0, 1)[0])
-
-    @property
-    def detector_start_line(self):
-        """
-        Returns starting detector line acquired from Spice Kernels.
-        Expects ikid to be defined. This should be the integer Naid ID code for
-        the instrument.
-
-        Returns
-        -------
-        : int
-          detector start line
-        """
-        return int(spice.gdpool('INS{}_FPUBIN_START_LINE'.format(self.ikid), 0, 1)[0])
 
     @property
     def detector_center_sample(self):

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 
 NAME = "Ale"
-VERSION = "0.6.0"
+VERSION = "0.6.2"
 
 # To install the library, run the following
 #

--- a/tests/pytests/test_mdis_drivers.py
+++ b/tests/pytests/test_mdis_drivers.py
@@ -149,8 +149,8 @@ image_dict = {
             'detector_center': {
                 'line': 512,
                 'sample': 512},
-            'starting_detector_line': 1,
-            'starting_detector_sample': 9,
+            'starting_detector_line': 0,
+            'starting_detector_sample': 0,
             'focal2pixel_lines': [0.0, 0.0, 71.42857143],
             'focal2pixel_samples': [0.0, 71.42857143, 0.0],
             'optical_distortion': {
@@ -209,18 +209,6 @@ class test_pds3_naif(unittest.TestCase):
             assert self.driver.focal_length == pytest.approx(6.0)
             gdpool.assert_called_with('INS-12345_FL_TEMP_COEFFS', 0, 6)
 
-    def test_detector_start_sample(self):
-        with patch('ale.drivers.mess_drivers.spice.gdpool', return_value=np.array([10.0])) as gdpool, \
-             patch('ale.base.data_naif.spice.bods2c', return_value=-12345) as bods2c:
-            assert self.driver.detector_start_sample == 10.0
-            gdpool.assert_called_with('INS-12345_FPUBIN_START_SAMPLE', 0, 1)
-
-    def test_detector_start_line(self):
-        with patch('ale.drivers.mess_drivers.spice.gdpool', return_value=np.array([10.0])) as gdpool, \
-             patch('ale.base.data_naif.spice.bods2c', return_value=-12345) as bods2c:
-            assert self.driver.detector_start_line == 10.0
-            gdpool.assert_called_with('INS-12345_FPUBIN_START_LINE', 0, 1)
-
     def test_detector_center_sample(self):
         assert self.driver.detector_center_sample == 512
 
@@ -273,18 +261,6 @@ class test_isis3_naif(unittest.TestCase):
              patch('ale.base.data_naif.spice.bods2c', return_value=-12345) as bods2c:
             assert self.driver.focal_length == pytest.approx(6.0)
             gdpool.assert_called_with('INS-12345_FL_TEMP_COEFFS', 0, 6)
-
-    def test_detector_start_sample(self):
-        with patch('ale.drivers.mess_drivers.spice.gdpool', return_value=np.array([10.0])) as gdpool, \
-             patch('ale.base.data_naif.spice.bods2c', return_value=-12345) as bods2c:
-            assert self.driver.detector_start_sample == 10.0
-            gdpool.assert_called_with('INS-12345_FPUBIN_START_SAMPLE', 0, 1)
-
-    def test_detector_start_line(self):
-        with patch('ale.drivers.mess_drivers.spice.gdpool', return_value=np.array([10.0])) as gdpool, \
-             patch('ale.base.data_naif.spice.bods2c', return_value=-12345) as bods2c:
-            assert self.driver.detector_start_line == 10.0
-            gdpool.assert_called_with('INS-12345_FPUBIN_START_LINE', 0, 1)
 
     def test_detector_center_sample(self):
         with patch('ale.drivers.mess_drivers.spice.gdpool', return_value=np.array([512.5, 512.5, 1])) as gdpool, \


### PR DESCRIPTION
This was ported over from ISIS, but was never actually used in ISIS, so it is being removed.