### PR TITLE
Fixed installing headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,16 +24,17 @@ find_package(nlohmann_json REQUIRED)
 add_library(ale SHARED
             ${CMAKE_CURRENT_SOURCE_DIR}/src/ale.cpp
             ${CMAKE_CURRENT_SOURCE_DIR}/src/Rotation.cpp)
-# Alias a scoped target for safer linking in downstream projects
-set(ALE_HEADERS "include/ale.h, include/Rotation.h")
+set(ALE_BUILD_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include/")
+set(ALE_HEADERS "${ALE_BUILD_INCLUDE_DIR}/ale.h"
+                "${ALE_BUILD_INCLUDE_DIR}/Rotation.h")
+set(ALE_INSTALL_INCLUDE_DIR "include/ale")
 set_target_properties(ale PROPERTIES
-                      VERSION       ${PROJECT_VERSION}
-                      SOVERSION     0
-                      PUBLIC_HEADER ${ALE_HEADERS})
+                      VERSION             ${PROJECT_VERSION}
+                      SOVERSION           0)
 # Use generator expressions so that downstream projects can use this target
 target_include_directories(ale
                            PUBLIC
-                           $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+                           $<BUILD_INTERFACE:${ALE_BUILD_INCLUDE_DIR}>
                            $<INSTALL_INTERFACE:include>)
 
 target_link_libraries(ale
@@ -73,11 +74,14 @@ configure_file(cmake/config.cmake.in
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake
               DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME})
 
+# Install the headers
+install(FILES ${ALE_HEADERS} DESTINATION ${ALE_INSTALL_INCLUDE_DIR})
+
 # Install the library
 install(TARGETS ale
         EXPORT aleTargets
-        LIBRARY       DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+        LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        INCLUDES DESTINATION ${ALE_INSTALL_INCLUDE_DIR})
 
 # Install the target
 install(EXPORT aleTargets


### PR DESCRIPTION
The PUBLIC_HEADER option only allows for a single file. This change ensures all of the headers are installed properly and the find_package config still works.