### PR TITLE
Disabled CaSSIS, Hyaabusa2 ONC, JunoCam, MEX HRSC, and Themis

### DIFF
--- a/ale/drivers/__init__.py
+++ b/ale/drivers/__init__.py
@@ -20,8 +20,16 @@ from ale.base.data_isis import IsisSpice
 
 from abc import ABC
 
+# Explicit list of disabled drivers
+__disabled_drivers__ = ["ody_drivers",
+                        "hayabusa2_drivers",
+                        "juno_drivers",
+                        "mex_drivers",
+                        "tgo_drivers"]
+
 # dynamically load drivers
 __all__ = [os.path.splitext(os.path.basename(d))[0] for d in glob(os.path.join(os.path.dirname(__file__), '*_drivers.py'))]
+__all__ = [driver for driver in __all__ if driver not in __disabled_drivers__]
 __driver_modules__ = [importlib.import_module('.'+m, package='ale.drivers') for m in __all__]
 
 __formatters__ = {'usgscsm': to_usgscsm,

--- a/tests/pytests/test_cassis_drivers.py
+++ b/tests/pytests/test_cassis_drivers.py
@@ -269,6 +269,7 @@ def test_kernels(scope="module"):
     for kern in binary_kernels:
         os.remove(kern)
 
+@pytest.mark.xfail
 def test_cassis_load(test_kernels, isis_compare_dict):
     label_file = get_image_label("CAS-MCO-2016-11-26T22.32.14.582-RED-01000-B1", "isis")
     isis_isd = ale.load(label_file, props={'kernels': test_kernels}, formatter="isis")

--- a/tests/pytests/test_hayabusa2_drivers.py
+++ b/tests/pytests/test_hayabusa2_drivers.py
@@ -169,6 +169,7 @@ def test_kernels():
             os.remove(kern)
 
 
+@pytest.mark.xfail
 @pytest.mark.parametrize("label_type", ['isis3'])
 @pytest.mark.parametrize("formatter", ['isis'])
 @pytest.mark.parametrize("image", image_dict.keys())

--- a/tests/pytests/test_juno_drivers.py
+++ b/tests/pytests/test_juno_drivers.py
@@ -121,6 +121,7 @@ def test_kernels():
     for kern in binary_kernels:
         os.remove(kern)
 
+@pytest.mark.xfail
 @pytest.mark.parametrize("label_type", ['isis3'])
 @pytest.mark.parametrize("formatter", ['isis'])
 def test_mro_load(test_kernels, label_type, formatter, isis_compare_dict):

--- a/tests/pytests/test_mex_drivers.py
+++ b/tests/pytests/test_mex_drivers.py
@@ -483,6 +483,7 @@ def test_kernels():
 
 # Eventually all label/formatter combinations should be tested. For now, isis3/usgscsm and
 # pds3/isis will fail.
+@pytest.mark.xfail
 @pytest.mark.parametrize("label,formatter", [('isis3','isis'), ('pds3', 'usgscsm'),
                                               pytest.param('isis3','usgscsm', marks=pytest.mark.xfail),
                                               pytest.param('pds3','isis', marks=pytest.mark.xfail),])

--- a/tests/pytests/test_themis_drivers.py
+++ b/tests/pytests/test_themis_drivers.py
@@ -277,6 +277,7 @@ def test_kernels():
         for kern in kern_list:
             os.remove(kern)
 
+@pytest.mark.xfail
 @pytest.mark.parametrize("label_type", ['isis3'])
 @pytest.mark.parametrize("formatter", ['isis'])
 @pytest.mark.parametrize("image", image_dict.keys())
@@ -334,4 +335,3 @@ class test_themisvis_isis_naif(unittest.TestCase):
 
     def test_sensor_model_version(self):
         assert self.driver.sensor_model_version == 1
-


### PR DESCRIPTION
We are disabling these drivers right now because they are having issues getting the correct values in the NaifKeywords for ISIS.

I left the tests in and tagged them as expected failures to ensure that they are disabled.