### PR TITLE
Removed py finalize call

### DIFF
--- a/src/ale.cpp
+++ b/src/ale.cpp
@@ -343,7 +343,6 @@ namespace ale {
          // Initialize the Python interpreter but only once.
          first_run = !first_run;
          Py_Initialize();
-         atexit(Py_Finalize);
      }
 
      // Import the file as a Python module.


### PR DESCRIPTION
This is causing assertion errors in Python threading under certain conditions. Python will already clean-up at exit, so I don't think we need to clean up the interpreter ourselves.