### PR TITLE
fikid vars now included in naif_keywords. 

### DIFF
--- a/ale/base/data_naif.py
+++ b/ale/base/data_naif.py
@@ -535,8 +535,7 @@ class NaifSpice():
             self._naif_keywords = {**self._naif_keywords, **util.query_kernel_pool(f"*{self.ikid}*"),  **util.query_kernel_pool(f"*{self.target_id}*")}
 
             try:
-                fikid_keywords = util.query_kernel_pool(f"*{self.fikid}*")
-                self._naif_keywords = {**self._naif_keywords, **fikid_keywords}
+                self._naif_keywords = {**self._naif_keywords, **util.query_kernel_pool(f"*{self.fikid}*")}
             except AttributeError as error:
                 pass
 

--- a/ale/drivers/__init__.py
+++ b/ale/drivers/__init__.py
@@ -52,7 +52,7 @@ class AleJsonEncoder(json.JSONEncoder):
             return obj.isoformat()
         return json.JSONEncoder.default(self, obj)
 
-def load(label, props={}, formatter='usgscsm', verbose=False):
+def load(label, props={}, formatter='usgscsm', verbose=True):
     """
     Attempt to load a given label from all possible drivers
 
@@ -66,6 +66,7 @@ def load(label, props={}, formatter='usgscsm', verbose=False):
 
     drivers = chain.from_iterable(inspect.getmembers(dmod, lambda x: inspect.isclass(x) and "_driver" in x.__module__) for dmod in __driver_modules__)
     drivers = sort_drivers([d[1] for d in drivers])
+    print(drivers)
 
     for driver in drivers:
         if verbose:
@@ -87,6 +88,6 @@ def load(label, props={}, formatter='usgscsm', verbose=False):
                 traceback.print_exc()
     raise Exception('No Such Driver for Label')
 
-def loads(label, props='', formatter='usgscsm', verbose=False):
+def loads(label, props='', formatter='usgscsm', verbose=True):
     res = load(label, props, formatter, verbose=verbose)
     return json.dumps(res, cls=AleJsonEncoder)

--- a/ale/drivers/__init__.py
+++ b/ale/drivers/__init__.py
@@ -52,7 +52,7 @@ class AleJsonEncoder(json.JSONEncoder):
             return obj.isoformat()
         return json.JSONEncoder.default(self, obj)
 
-def load(label, props={}, formatter='usgscsm', verbose=True):
+def load(label, props={}, formatter='usgscsm', verbose=False):
     """
     Attempt to load a given label from all possible drivers
 
@@ -66,7 +66,6 @@ def load(label, props={}, formatter='usgscsm', verbose=True):
 
     drivers = chain.from_iterable(inspect.getmembers(dmod, lambda x: inspect.isclass(x) and "_driver" in x.__module__) for dmod in __driver_modules__)
     drivers = sort_drivers([d[1] for d in drivers])
-    print(drivers)
 
     for driver in drivers:
         if verbose:
@@ -88,6 +87,6 @@ def load(label, props={}, formatter='usgscsm', verbose=True):
                 traceback.print_exc()
     raise Exception('No Such Driver for Label')
 
-def loads(label, props='', formatter='usgscsm', verbose=True):
+def loads(label, props='', formatter='usgscsm', verbose=False):
     res = load(label, props, formatter, verbose=verbose)
     return json.dumps(res, cls=AleJsonEncoder)

--- a/tests/ctests/CMakeLists.txt
+++ b/tests/ctests/CMakeLists.txt
@@ -12,6 +12,8 @@ target_link_libraries(runAleTests
                       GSL::gslcblas
                       Eigen3::Eigen
                       gtest
-                      Threads::Threads)
+                      Threads::Threads
+                      nlohmann_json::nlohmann_json
+                      )
 
 gtest_discover_tests(runAleTests WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}/tests/ctests)

--- a/tests/pytests/conftest.py
+++ b/tests/pytests/conftest.py
@@ -77,6 +77,8 @@ image_2_data = {}
 for d in dirs:
     tmp = os.path.join(data_root, d)
     image_2_data[d] = [os.path.join(tmp, f) for f in os.listdir(tmp) if not f.startswith('.') and os.path.splitext(f)[1] != '.lbl']
+    # force IAKs to the back of the list
+    image_2_data[d] = sorted(image_2_data[d], key=lambda x: "Addendum" in x)
 
 def get_image_label(image, label_type='pds3'):
     if not isinstance(image, str):

--- a/tests/pytests/test_mex_drivers.py
+++ b/tests/pytests/test_mex_drivers.py
@@ -546,7 +546,6 @@ def test_kernels():
 
 # Eventually all label/formatter combinations should be tested. For now, isis3/usgscsm and
 # pds3/isis will fail.
-@pytest.mark.xfail
 @pytest.mark.parametrize("label,formatter", [('isis3','isis'), ('pds3', 'usgscsm'),
                                               pytest.param('isis3','usgscsm', marks=pytest.mark.xfail),
                                               pytest.param('pds3','isis', marks=pytest.mark.xfail),])
@@ -573,7 +572,6 @@ def test_mex_load(test_kernels, formatter, usgscsm_compare_dict, label):
 
         usgscsm_isd = ale.load(label_file, props={'kernels': test_kernels}, formatter=formatter, verbose='true')
         assert compare_dicts(usgscsm_isd, usgscsm_compare_dict['h5270_0000_ir2'][formatter]) == []
-        assert False
 
 # ========= Test mex pds3label and naifspice driver =========
 class test_mex_pds3_naif(unittest.TestCase):

--- a/tests/pytests/test_mex_drivers.py
+++ b/tests/pytests/test_mex_drivers.py
@@ -546,6 +546,7 @@ def test_kernels():
 
 # Eventually all label/formatter combinations should be tested. For now, isis3/usgscsm and
 # pds3/isis will fail.
+@pytest.mark.xfail
 @pytest.mark.parametrize("label,formatter", [('isis3','isis'), ('pds3', 'usgscsm'),
                                               pytest.param('isis3','usgscsm', marks=pytest.mark.xfail),
                                               pytest.param('pds3','isis', marks=pytest.mark.xfail),])


### PR DESCRIPTION
Mostly based on https://github.com/USGS-Astrogeology/ale/pull/321

Instruments with filters will want naif keywords with fikids in them (right now HRSC and messenger)