### PR TITLE
re-enabled mex

### DIFF
--- a/ale/drivers/__init__.py
+++ b/ale/drivers/__init__.py
@@ -24,7 +24,6 @@ from abc import ABC
 __disabled_drivers__ = ["ody_drivers",
                         "hayabusa2_drivers",
                         "juno_drivers",
-                        "mex_drivers",
                         "tgo_drivers"]
 
 # dynamically load drivers

--- a/tests/pytests/test_mex_drivers.py
+++ b/tests/pytests/test_mex_drivers.py
@@ -546,7 +546,6 @@ def test_kernels():
 
 # Eventually all label/formatter combinations should be tested. For now, isis3/usgscsm and
 # pds3/isis will fail.
-@pytest.mark.xfail
 @pytest.mark.parametrize("label,formatter", [('isis3','isis'), ('pds3', 'usgscsm'),
                                               pytest.param('isis3','usgscsm', marks=pytest.mark.xfail),
                                               pytest.param('pds3','isis', marks=pytest.mark.xfail),])


### PR DESCRIPTION
This puts MEX back in as ale::load-able 