### PR TITLE
LRO Direction Fix + Summing Mode Fix

### DIFF
--- a/ale/base/data_naif.py
+++ b/ale/base/data_naif.py
@@ -411,7 +411,9 @@ class NaifSpice():
                 v_vec = rotated_velocities
 
                 velocity_axis = 2
-                trans_x = self.focal2pixel_lines
+                # Get the default line translation with no potential flipping
+                # from the driver
+                trans_x = np.array(list(spice.gdpool('INS{}_ITRANSL'.format(self.ikid), 0, 3)))
 
                 if (trans_x[0] < trans_x[1]):
                     velocity_axis = 1

--- a/ale/drivers/lro_drivers.py
+++ b/ale/drivers/lro_drivers.py
@@ -141,7 +141,7 @@ class LroLrocPds3LabelNaifSpiceDriver(LineScanner, NaifSpice, Pds3Label, Driver)
         : list<double>
           focal plane to detector lines
         """
-        focal2pixel_lines = np.array(list(spice.gdpool('INS{}_ITRANSL'.format(self.ikid), 0, 3)))
+        focal2pixel_lines = np.array(list(spice.gdpool('INS{}_ITRANSL'.format(self.ikid), 0, 3))) / self.sampling_factor
         if self.spacecraft_direction < 0:
             return -focal2pixel_lines
         else:
@@ -406,7 +406,7 @@ class LroLrocIsisLabelNaifSpiceDriver(LineScanner, NaifSpice, IsisLabel, Driver)
         : list<double>
           focal plane to detector lines
         """
-        focal2pixel_lines = np.array(list(spice.gdpool('INS{}_ITRANSL'.format(self.ikid), 0, 3)))
+        focal2pixel_lines = np.array(list(spice.gdpool('INS{}_ITRANSL'.format(self.ikid), 0, 3))) / self.sampling_factor
         if self.spacecraft_direction < 0:
             return -focal2pixel_lines
         else:

--- a/ale/drivers/lro_drivers.py
+++ b/ale/drivers/lro_drivers.py
@@ -142,7 +142,10 @@ class LroLrocPds3LabelNaifSpiceDriver(LineScanner, NaifSpice, Pds3Label, Driver)
           focal plane to detector lines
         """
         focal2pixel_lines = np.array(list(spice.gdpool('INS{}_ITRANSL'.format(self.ikid), 0, 3)))
-        return focal2pixel_lines
+        if self.spacecraft_direction < 0:
+            return -focal2pixel_lines
+        else:
+            return focal2pixel_lines
 
     @property
     def ephemeris_start_time(self):
@@ -259,10 +262,15 @@ class LroLrocPds3LabelNaifSpiceDriver(LineScanner, NaifSpice, Pds3Label, Driver)
         direction : double
                     X value of the first velocity relative to the sensor
         """
-        rotation = self.frame_chain.compute_rotation(self.target_frame_id, self.sensor_frame_id)
-        positions, velocities, times = self.sensor_position
-        velocity = rotation.rotate_velocity_at([positions[0]], [velocities[0]], [times[0]])[0]
-        return velocity[0]
+        frame_chain = self.frame_chain
+        lro_bus_id = spice.bods2c('LRO_SC_BUS')
+        time = self.ephemeris_start_time
+        state, _ = spice.spkezr(self.spacecraft_name, time, 'J2000', 'None', self.target_name)
+        position = state[:3]
+        velocity = state[3:]
+        rotation = frame_chain.compute_rotation(1, lro_bus_id)
+        rotated_velocity = spice.mxv(rotation._rots.as_dcm()[0], velocity)
+        return rotated_velocity[0]
 
 
 
@@ -399,7 +407,10 @@ class LroLrocIsisLabelNaifSpiceDriver(LineScanner, NaifSpice, IsisLabel, Driver)
           focal plane to detector lines
         """
         focal2pixel_lines = np.array(list(spice.gdpool('INS{}_ITRANSL'.format(self.ikid), 0, 3)))
-        return focal2pixel_lines
+        if self.spacecraft_direction < 0:
+            return -focal2pixel_lines
+        else:
+            return focal2pixel_lines
 
     @property
     def multiplicative_line_error(self):
@@ -485,7 +496,12 @@ class LroLrocIsisLabelNaifSpiceDriver(LineScanner, NaifSpice, IsisLabel, Driver)
         direction : double
                     X value of the first velocity relative to the sensor
         """
-        rotation = self.frame_chain.compute_rotation(self.target_frame_id, self.sensor_frame_id)
-        positions, velocities, times = self.sensor_position
-        velocity = rotation.rotate_velocity_at([positions[0]], [velocities[0]], [times[0]])[0]
-        return velocity[0]
+        frame_chain = self.frame_chain
+        lro_bus_id = spice.bods2c('LRO_SC_BUS')
+        time = self.ephemeris_start_time
+        state, _ = spice.spkezr(self.spacecraft_name, time, 'J2000', 'None', self.target_name)
+        position = state[:3]
+        velocity = state[3:]
+        rotation = frame_chain.compute_rotation(1, lro_bus_id)
+        rotated_velocity = spice.mxv(rotation._rots.as_dcm()[0], velocity)
+        return rotated_velocity[0]


### PR DESCRIPTION
Updated spacecraft direction for lro and  adds the necessary checks where needed. 

Also addresses an issue with the summing mode. The sampling factor from LRO needs to be accounted for in the focal2pixel translation in the new line scanner groundToImage algorithm in CSM.