### PR TITLE
Fixed constant rotations in Orientations

### DIFF
--- a/include/ale/Isd.h
+++ b/include/ale/Isd.h
@@ -62,8 +62,6 @@ namespace ale {
 
     PositionInterpolation interpMethod;
 
-    Rotation const_rotation;
-
     States inst_pos;
     States sun_pos;
 

--- a/include/ale/Orientations.h
+++ b/include/ale/Orientations.h
@@ -21,7 +21,6 @@ namespace ale {
       const std::vector<Rotation> &rotations,
       const std::vector<double> &times,
       const std::vector<Vec3d> &avs = std::vector<ale::Vec3d>(),
-      const int refFrame = 1,
       const Rotation &constRot = Rotation(1, 0, 0, 0),
       const std::vector<int> const_frames = std::vector<int>(),
       const std::vector<int> time_dependent_frames = std::vector<int>()
@@ -40,7 +39,6 @@ namespace ale {
     std::vector<double> getTimes() const;
     std::vector<int> getConstantFrames() const;
     std::vector<int> getTimeDependentFrames() const;
-    int getReferenceFrame() const;
     Rotation getConstantRotation() const;
 
     /**
@@ -89,7 +87,6 @@ namespace ale {
     std::vector<int> m_timeDepFrames;
     std::vector<int> m_constFrames;
     Rotation m_constRotation;
-    int m_refFrame;
   };
 }
 

--- a/src/Util.cpp
+++ b/src/Util.cpp
@@ -534,7 +534,6 @@ Orientations getInstrumentPointing(json isd) {
     std::vector<Rotation> rotations = getJsonQuatArray(pointing.at("quaternions"));
     std::vector<double> times = getJsonArray<double>(pointing.at("ephemeris_times"));
     std::vector<Vec3d> velocities = getJsonVec3dArray(pointing.at("angular_velocities"));
-    int refFrame = pointing.at("reference_frame").get<int>();
 
     std::vector<int> constFrames;
     if (pointing.find("constant_frames") != pointing.end()){
@@ -553,7 +552,7 @@ Orientations getInstrumentPointing(json isd) {
 
     Rotation constRot(rotArray);
 
-    Orientations orientation(rotations, times, velocities, refFrame, constRot, constFrames, timeDepFrames);
+    Orientations orientation(rotations, times, velocities, constRot, constFrames, timeDepFrames);
 
     return orientation;
 
@@ -568,8 +567,6 @@ Orientations getBodyRotation(json isd) {
     std::vector<Rotation> rotations = getJsonQuatArray(bodrot.at("quaternions"));
     std::vector<double> times = getJsonArray<double>(bodrot.at("ephemeris_times"));
     std::vector<Vec3d> velocities = getJsonVec3dArray(bodrot.at("angular_velocities"));
-
-    int refFrame = bodrot.at("reference_frame").get<int>();
 
     std::vector<int> constFrames;
     if (bodrot.find("constant_frames") != bodrot.end()){
@@ -588,7 +585,7 @@ Orientations getBodyRotation(json isd) {
 
     Rotation constRot(rotArray);
 
-    Orientations orientation(rotations, times, velocities, refFrame, constRot, constFrames, timeDepFrames);
+    Orientations orientation(rotations, times, velocities, constRot, constFrames, timeDepFrames);
     return orientation;
 
   } catch (...) {

--- a/tests/ctests/IsdTests.cpp
+++ b/tests/ctests/IsdTests.cpp
@@ -274,7 +274,6 @@ TEST(Isd, GetInstrumentPointing) {
   std::vector<int> timeDepFrames = instPointing.getTimeDependentFrames();
 
   ASSERT_EQ(rotations.size(), 2);
-  ASSERT_EQ(instPointing.getReferenceFrame(), 2);
   ASSERT_EQ(instPointing.getTimes()[0], 300);
   ASSERT_EQ(instPointing.getTimes()[1], 600);
 
@@ -345,7 +344,6 @@ TEST(Isd, GetBodyRotation) {
   std::vector<int> timeDepFrames = bodyRot.getTimeDependentFrames();
 
   ASSERT_EQ(rotations.size(), 2);
-  ASSERT_EQ(bodyRot.getReferenceFrame(), 2);
   ASSERT_EQ(bodyRot.getTimes()[0], 300);
   ASSERT_EQ(bodyRot.getTimes()[1], 600);
 

--- a/tests/ctests/OrientationsTests.cpp
+++ b/tests/ctests/OrientationsTests.cpp
@@ -29,6 +29,18 @@ class OrientationTest : public ::testing::Test {
     Orientations orientations;
 };
 
+class ConstOrientationTest : public OrientationTest{
+  protected:
+    void SetUp() override {
+      OrientationTest::SetUp();
+      constRotation = Rotation(0, 1, 0, 0);
+      constOrientations = Orientations(rotations, times, avs, constRotation);
+    }
+
+    Rotation constRotation;
+    Orientations constOrientations;
+};
+
 TEST_F(OrientationTest, ConstructorAccessors) {
   vector<Rotation> outputRotations = orientations.getRotations();
   vector<double> outputTimes = orientations.getTimes();
@@ -129,4 +141,44 @@ TEST_F(OrientationTest, OrientationMultiplication) {
     EXPECT_EQ(expectedQuats[i][2], quats[2]);
     EXPECT_EQ(expectedQuats[i][3], quats[3]);
   }
+}
+
+TEST_F(ConstOrientationTest, RotateAt) {
+  Vec3d rotatedX = constRotation(orientations.rotateVectorAt(0.0, Vec3d(1.0, 0.0, 0.0)));
+  Vec3d constRotatedX = constOrientations.rotateVectorAt(0.0, Vec3d(1.0, 0.0, 0.0));
+  EXPECT_NEAR(rotatedX.x, constRotatedX.x, 1e-10);
+  EXPECT_NEAR(rotatedX.y, constRotatedX.y, 1e-10);
+  EXPECT_NEAR(rotatedX.z, constRotatedX.z, 1e-10);
+  Vec3d rotatedY = constRotation(orientations.rotateVectorAt(0.0, Vec3d(0.0, 1.0, 0.0)));
+  Vec3d constRotatedY = constOrientations.rotateVectorAt(0.0, Vec3d(0.0, 1.0, 0.0));
+  EXPECT_NEAR(rotatedY.x, constRotatedY.x, 1e-10);
+  EXPECT_NEAR(rotatedY.y, constRotatedY.y, 1e-10);
+  EXPECT_NEAR(rotatedY.z, constRotatedY.z, 1e-10);
+  Vec3d rotatedZ = constRotation(orientations.rotateVectorAt(0.0, Vec3d(0.0, 0.0, 1.0)));
+  Vec3d constRotatedZ = constOrientations.rotateVectorAt(0.0, Vec3d(0.0, 0.0, 1.0));
+  EXPECT_NEAR(rotatedZ.x, constRotatedZ.x, 1e-10);
+  EXPECT_NEAR(rotatedZ.y, constRotatedZ.y, 1e-10);
+  EXPECT_NEAR(rotatedZ.z, constRotatedZ.z, 1e-10);
+}
+
+TEST_F(ConstOrientationTest, OrientationMultiplication) {
+  constOrientations *= orientations;
+  vector<Rotation> outputRotations = constOrientations.getRotations();
+  vector<vector<double>> expectedQuats = {
+    {-0.5, 0.5, 0.5, 0.5},
+    {-0.5,-0.5,-0.5,-0.5},
+    { 1.0, 0.0, 0.0, 0.0}
+  };
+  for (size_t i = 0; i < outputRotations.size(); i++) {
+    vector<double> quats = outputRotations[i].toQuaternion();
+    EXPECT_EQ(expectedQuats[i][0], quats[0]);
+    EXPECT_EQ(expectedQuats[i][1], quats[1]);
+    EXPECT_EQ(expectedQuats[i][2], quats[2]);
+    EXPECT_EQ(expectedQuats[i][3], quats[3]);
+  }
+  vector<double> constQuats = constOrientations.getConstantRotation().toQuaternion();
+  EXPECT_EQ(constQuats[0], 0);
+  EXPECT_EQ(constQuats[1], 1);
+  EXPECT_EQ(constQuats[2], 0);
+  EXPECT_EQ(constQuats[3], 0);
 }


### PR DESCRIPTION
This fixed a couple things in Orientations:

1. Orientations don't have a single references frame, they are the transformations between reference frames.
1. The constant rotation wasn't actually being used anywhere. Now, when you use rotateAt, it will properly include the constant rotation.