### PR TITLE
Pfeffernusse Loading Fixes

### DIFF
--- a/ale/base/label_pds3.py
+++ b/ale/base/label_pds3.py
@@ -10,12 +10,13 @@ class Pds3Label():
         if not hasattr(self, "_label"):
             if isinstance(self._file, pvl.PVLModule):
                 self._label = self._file
-            try:
-                self._label = pvl.loads(self._file)
-            except Exception:
-                self._label = pvl.load(self._file)
-            except:
-                raise ValueError("{} is not a valid label".format(self._file))
+            else:
+                try:
+                    self._label = pvl.loads(self._file, strict=False)
+                except Exception:
+                    self._label = pvl.load(self._file)
+                except:
+                    raise ValueError("{} is not a valid label".format(self._file))
         return self._label
 
 

--- a/ale/drivers/co_drivers.py
+++ b/ale/drivers/co_drivers.py
@@ -308,13 +308,20 @@ class CassiniIssPds3LabelNaifSpiceDriver(Framer, Pds3Label, NaifSpice, RadialDis
           Custom Cassini ALE Frame Chain object for rotation computation and application
         """
         if not hasattr(self, '_frame_chain'):
-            self._frame_chain = FrameChain.from_spice(sensor_frame=self._original_naif_sensor_frame_id,
-                                                      target_frame=self.target_frame_id,
-                                                      center_ephemeris_time=self.center_ephemeris_time,
-                                                      ephemeris_times=self.ephemeris_time,)
 
-            rotation = ConstantRotation([[0, 0, 1, 0]], self.sensor_frame_id, self._original_naif_sensor_frame_id)
+            try:
+                # Call frinfo to check if the ISIS iak has been loaded with the
+                # additional reference frame. Otherwise, Fail and add it manually
+                spice.frinfo(self.sensor_frame_id)
+                self._frame_chain = super().frame_chain
+            except spice.utils.exceptions.NotFoundError as e:
+                self._frame_chain = FrameChain.from_spice(sensor_frame=self._original_naif_sensor_frame_id,
+                                                          target_frame=self.target_frame_id,
+                                                          center_ephemeris_time=self.center_ephemeris_time,
+                                                          ephemeris_times=self.ephemeris_time,)
 
-            self._frame_chain.add_edge(rotation=rotation)
+                rotation = ConstantRotation([[0, 0, 1, 0]], self.sensor_frame_id, self._original_naif_sensor_frame_id)
+
+                self._frame_chain.add_edge(rotation=rotation)
 
         return self._frame_chain

--- a/ale/drivers/co_drivers.py
+++ b/ale/drivers/co_drivers.py
@@ -269,7 +269,8 @@ class CassiniIssPds3LabelNaifSpiceDriver(Framer, Pds3Label, NaifSpice, RadialDis
         is the frame ID you want to default to for WAC. For NAC, this Frame ID
         sits between J2000 and an extra 180 rotation since NAC was mounted
         upside down.
-         Returns
+
+        Returns
         -------
         : int
           sensor frame code from NAIF's IK kernel
@@ -284,11 +285,12 @@ class CassiniIssPds3LabelNaifSpiceDriver(Framer, Pds3Label, NaifSpice, RadialDis
         kernel for Cassini. This is because NAC requires an extra rotation not
         in NAIF's Cassini kernels. Wac does not require an extra rotation so
         we simply return original sensor frame id for Wac.
-         Returns
+
+        Returns
         -------
         : int
           NAIF's Wac sensor frame ID, or ALE's Nac sensor frame ID
-         """
+        """
         if self.instrument_id == "CASSINI_ISS_NAC":
           return 14082360
         elif self.instrument_id == "CASSINI_ISS_WAC":
@@ -296,6 +298,15 @@ class CassiniIssPds3LabelNaifSpiceDriver(Framer, Pds3Label, NaifSpice, RadialDis
 
     @property
     def frame_chain(self):
+        """
+        Construct the initial frame chain using the original sensor_frame_id
+        obtained from the ikid. Then tack on the ISIS iak rotation.
+
+        Returns
+        -------
+        : Object
+          Custom Cassini ALE Frame Chain object for rotation computation and application
+        """
         if not hasattr(self, '_frame_chain'):
             self._frame_chain = FrameChain.from_spice(sensor_frame=self._original_naif_sensor_frame_id,
                                                       target_frame=self.target_frame_id,

--- a/ale/drivers/co_drivers.py
+++ b/ale/drivers/co_drivers.py
@@ -77,7 +77,6 @@ class CassiniIssPds3LabelNaifSpiceDriver(Framer, Pds3Label, NaifSpice, RadialDis
         ("P120","UV3"):2002.71
     }
 
-
     wac_filter_to_focal_length = {
         ("B2","CL2"):200.85,
         ("B2","IRP90"):200.83,
@@ -262,40 +261,3 @@ class CassiniIssPds3LabelNaifSpiceDriver(Framer, Pds3Label, NaifSpice, RadialDis
 
         elif self.instrument_id == "CASSINI_ISS_WAC":
           return self.wac_filter_to_focal_length.get(filters, default_focal_len)
-
-    @property
-    def _original_naif_sensor_frame_id(self):
-        """
-        Original sensor frame ID as defined in Cassini's IK kernel. This
-        is the frame ID you want to default to for WAC. For NAC, this Frame ID
-        sits between J2000 and an extra 180 rotation since NAC was mounted
-        upside down.
-
-        Returns
-        -------
-        : int
-          sensor frame code from NAIF's IK kernel
-        """
-        return self.ikid
-
-    @property
-    def sensor_frame_id(self):
-        """
-        Overwrite sensor frame id to return fake frame ID for NAC representing a
-        mounting point with a 180 degree rotation. ID was taken from ISIS's IAK
-        kernel for Cassini. This is because NAC requires an extra rotation not
-        in NAIF's Cassini kernels. Wac does not require an extra rotation so
-        we simply return original sensor frame id for Wac.
-
-        Returns
-        -------
-        : int
-          NAIF's Wac sensor frame ID, or ALE's Nac sensor frame ID
-
-        """
-        if self.instrument_id == "CASSINI_ISS_NAC":
-          return 14082360
-        elif self.instrument_id == "CASSINI_ISS_WAC":
-          return 14082361
-
-

--- a/ale/drivers/co_drivers.py
+++ b/ale/drivers/co_drivers.py
@@ -296,10 +296,14 @@ class CassiniIssPds3LabelNaifSpiceDriver(Framer, Pds3Label, NaifSpice, RadialDis
 
     @property
     def frame_chain(self):
-        if not hasattr(self, '_cassini_frame_chain'):
-            self._cassini_frame_chain = super().frame_chain
+        if not hasattr(self, '_frame_chain'):
+            self._frame_chain = FrameChain.from_spice(sensor_frame=self._original_naif_sensor_frame_id,
+                                                      target_frame=self.target_frame_id,
+                                                      center_ephemeris_time=self.center_ephemeris_time,
+                                                      ephemeris_times=self.ephemeris_time,)
 
             rotation = ConstantRotation([[0, 0, 1, 0]], self.sensor_frame_id, self._original_naif_sensor_frame_id)
 
-            self._cassini_frame_chain.add_edge(rotation=rotation)
-        return self._cassini_frame_chain
+            self._frame_chain.add_edge(rotation=rotation)
+
+        return self._frame_chain

--- a/ale/util.py
+++ b/ale/util.py
@@ -79,7 +79,7 @@ def get_metakernels(spice_dir=spice_root, missions=set(), years=set(), versions=
         metakernel_keys = ['mission', 'year', 'version', 'path']
 
         # recursive glob to make metakernel search more robust to subtle directory structure differences
-        metakernel_paths = sorted(glob(os.path.join(md, '**','*.tm'), recursive=True))
+        metakernel_paths = sorted(glob(os.path.join(md, '**','*.[Tt][Mm]'), recursive=True))
 
         metakernels = []
         for k in metakernel_paths:

--- a/tests/pytests/test_cassini_drivers.py
+++ b/tests/pytests/test_cassini_drivers.py
@@ -85,6 +85,3 @@ class test_cassini_pds3_naif(unittest.TestCase):
 
     def test_sensor_model_version(self):
         assert self.driver.sensor_model_version == 1
-
-    def test_sensor_frame_id(self):
-        assert self.driver.sensor_frame_id == 14082360

--- a/tests/pytests/test_cassini_drivers.py
+++ b/tests/pytests/test_cassini_drivers.py
@@ -5,7 +5,7 @@ import os
 import numpy as np
 from ale.drivers import co_drivers
 import unittest
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 import json
 from conftest import get_image_label, get_image_kernels, get_isd, convert_kernels, compare_dicts
 
@@ -85,3 +85,21 @@ class test_cassini_pds3_naif(unittest.TestCase):
 
     def test_sensor_model_version(self):
         assert self.driver.sensor_model_version == 1
+
+    def test_sensor_frame_id(self):
+        assert self.driver.sensor_frame_id == 14082360
+
+    @patch('ale.transformation.FrameChain.from_spice', return_value=ale.transformation.FrameChain())
+    def test_custom_frame_chain(self, from_spice):
+        with patch('ale.drivers.co_drivers.spice.bods2c', return_value=-12345) as bods2c, \
+             patch('ale.drivers.co_drivers.CassiniIssPds3LabelNaifSpiceDriver.target_frame_id', \
+                     new_callable=PropertyMock) as target_frame_id, \
+             patch('ale.drivers.co_drivers.CassiniIssPds3LabelNaifSpiceDriver.ephemeris_start_time', \
+                     new_callable=PropertyMock) as ephemeris_start_time:
+            ephemeris_start_time.return_value = .1
+            target_frame_id.return_value = -800
+            frame_chain = self.driver.frame_chain
+            assert len(frame_chain.nodes()) == 2
+            assert 14082360 in frame_chain.nodes()
+            assert -12345 in frame_chain.nodes()
+            from_spice.assert_called_with(center_ephemeris_time=2.4, ephemeris_times=[2.4], sensor_frame=-12345, target_frame=-800)

--- a/tests/pytests/test_cassini_drivers.py
+++ b/tests/pytests/test_cassini_drivers.py
@@ -103,3 +103,17 @@ class test_cassini_pds3_naif(unittest.TestCase):
             assert 14082360 in frame_chain.nodes()
             assert -12345 in frame_chain.nodes()
             from_spice.assert_called_with(center_ephemeris_time=2.4, ephemeris_times=[2.4], sensor_frame=-12345, target_frame=-800)
+
+    @patch('ale.transformation.FrameChain.from_spice', return_value=ale.transformation.FrameChain())
+    def test_custom_frame_chain_iak(self, from_spice):
+        with patch('ale.drivers.co_drivers.spice.bods2c', return_value=-12345) as bods2c, \
+             patch('ale.drivers.co_drivers.CassiniIssPds3LabelNaifSpiceDriver.target_frame_id', \
+                     new_callable=PropertyMock) as target_frame_id, \
+             patch('ale.drivers.co_drivers.CassiniIssPds3LabelNaifSpiceDriver.ephemeris_start_time', \
+                     new_callable=PropertyMock) as ephemeris_start_time, \
+             patch('ale.drivers.co_drivers.spice.frinfo', return_value=True) as frinfo:
+            ephemeris_start_time.return_value = .1
+            target_frame_id.return_value = -800
+            frame_chain = self.driver.frame_chain
+            assert len(frame_chain.nodes()) == 0
+            from_spice.assert_called_with(center_ephemeris_time=2.4, ephemeris_times=[2.4], nadir=False, sensor_frame=14082360, target_frame=-800)


### PR DESCRIPTION
Changes necessary to get Pfeffernusse and ALE cooperating

- Allow ALE to find both caps and not caps metakernels
- Remove special sensor_frame_id from cassini (Fixed via a kernel update)
- If your label is a PVLModule don't also attempt to load it as if it were a file