### PR TITLE
Address spiceinit slowdown

### DIFF
--- a/ale/base/base.py
+++ b/ale/base/base.py
@@ -11,7 +11,7 @@ class Driver():
             Reference to file path to be used by mixins for opening.
     """
 
-    def __init__(self, file, num_ephem=909, num_quats=909, props={}):
+    def __init__(self, file, num_ephem=909, num_quats=909, props={}, parsed_label=None):
         """
         Parameters
         ----------
@@ -30,6 +30,9 @@ class Driver():
         self._num_quaternions = num_quats
         self._num_ephem = num_ephem
         self._file = file
+
+        if parsed_label:
+            self._label = parsed_label
 
     @property
     def image_lines(self):

--- a/ale/drivers/__init__.py
+++ b/ale/drivers/__init__.py
@@ -96,12 +96,16 @@ def load(label, props={}, formatter='ale', verbose=False):
     try:
         # Try default grammar for pds3 label
         parsed_label = parse_label(label)
-    except ValueError:
+    except ValueError as e:
+        if verbose:
+            print(e)
         # If pds3 label fails, try isis grammar
         parsed_label = parse_label(label, pvl.grammar.ISISGrammar)
-    except:
-        # If both fail, raise the error to the calling function
-        raise
+    except Exception as e:
+        if verbose:
+            print(e)
+        # If both fail, then don't parse the label, and just pass the driver a file.
+        parsed_label = None
 
     for driver in drivers:
         if verbose:
@@ -142,12 +146,28 @@ def loads(label, props='', formatter='ale', verbose=False):
     return json.dumps(res, cls=AleJsonEncoder)
 
 
-def parse_label(label, grammar=None):
+def parse_label(label, grammar=pvl.grammar.PVLGrammar):
+    """
+    Attempt to parse a PVL label.
+
+    Returns
+    -------
+    str
+        The label as a pvl string or pvl file.
+
+    grammar
+        The pvl grammar with which to parse the label. If None, default to PVLGrammar
+
+    See Also
+    --------
+    load
+    loads
+    """
     try:
         parsed_label = pvl.loads(label, grammar=grammar)
     except Exception:
         parsed_label = pvl.load(label, grammar=grammar)
     except:
-        raise ValueError("{} is not a valid label".format(label))
+        raise ValueError("{} is not a valid label for grammar {}".format(label, grammar.__name__))
 
     return parsed_label

--- a/ale/drivers/__init__.py
+++ b/ale/drivers/__init__.py
@@ -107,7 +107,7 @@ def load(label, props={}, formatter='ale', verbose=False):
         if verbose:
             print(f'Trying {driver}')
         try:
-            res = driver(label, props=props)
+            res = driver(label, props=props, parsed_label=parsed_label)
             # get instrument_id to force early failure
             res.instrument_id
 

--- a/ale/drivers/__init__.py
+++ b/ale/drivers/__init__.py
@@ -150,13 +150,19 @@ def parse_label(label, grammar=pvl.grammar.PVLGrammar):
     """
     Attempt to parse a PVL label.
 
-    Returns
-    -------
-    str
+    Parameters
+    ----------
+    label
         The label as a pvl string or pvl file.
 
     grammar
         The pvl grammar with which to parse the label. If None, default to PVLGrammar
+
+
+    Returns
+    -------
+    pvl.collections.PVLModule
+        The PVL label deserialized to a Python object
 
     See Also
     --------


### PR DESCRIPTION
Adds functionality to support passing drivers a parsed label in order to avoid a "parse per driver" scenario that was causing significant slowdowns.

The old functionality is preserved, i.e. allowing a driver to parse its own label is still supported.

Credit @amystamile-usgs for pair programming these changes