### PR TITLE
Added breathe to dev env

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -18,3 +18,4 @@ dependencies:
   - spiceypy>=2.3.0
   - pyyaml
   - networkx
+  - breathe


### PR DESCRIPTION
I much prefer having the docs dependency in the build env to having two separate env files to maintain.