### PR TITLE
0.8.6 version tick

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,4 +1,4 @@
-version: '0.8.5.{build}'
+version: '0.8.6.{build}'
 
 image: Visual Studio 2017
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@
 # Specify the required version of CMake.
 # cmake 3.15 required for findPython virtualenv configuration
 cmake_minimum_required(VERSION 3.15)
-project(ale VERSION 0.8.5 DESCRIPTION "Abstraction Library for Ephemerides ")
+project(ale VERSION 0.8.6 DESCRIPTION "Abstraction Library for Ephemerides ")
 
 # include what we need
 include(GNUInstallDirs)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.8.5" %}
+{% set version = "0.8.6" %}
 {% set git_branch = "master" %}
 {% set build_number = "0" %}
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from setuptools import setup, find_packages
 
 NAME = "Ale"
-VERSION = "0.8.5"
+VERSION = "0.8.6"
 
 # To install the library, run the following
 #


### PR DESCRIPTION
It's possible the meta.yaml should just go as we don't deploy a dev build from this repo