### PR TITLE
Have CSM write camera model files on multiple lines, for readability

### DIFF
--- a/ale/drivers/__init__.py
+++ b/ale/drivers/__init__.py
@@ -138,7 +138,7 @@ def load(label, props={}, formatter='ale', verbose=False):
                 traceback.print_exc()
     raise Exception('No Such Driver for Label')
 
-def loads(label, props='', formatter='ale', verbose=False):
+def loads(label, props='', formatter='ale', indent = 2, verbose=False):
     """
     Attempt to load a given label from all possible drivers.
 
@@ -154,8 +154,7 @@ def loads(label, props='', formatter='ale', verbose=False):
     load
     """
     res = load(label, props, formatter, verbose=verbose)
-    return json.dumps(res, cls=AleJsonEncoder)
-
+    return json.dumps(res, indent=indent, cls=AleJsonEncoder)
 
 def parse_label(label, grammar=pvl.grammar.PVLGrammar()):
     """


### PR DESCRIPTION
This is a proposed fix for https://github.com/USGS-Astrogeology/usgscsm/issues/337.

I've worked extensively with .json files produced by ALE recently and having the whole file in a single line makes it very hard to understand what is in the model and do comparisons, etc.

This fix makes the .json files be written on multiple lines and nicely indented. (The whole point of json is to provide a pretty and simple format, unlike XML, so this way, with pretty indentation, json achieve its full potential.)