### PR TITLE
Save center_ephemeris_time to the SAR sensor model

### DIFF
--- a/ale/formatters/usgscsm_formatter.py
+++ b/ale/formatters/usgscsm_formatter.py
@@ -157,6 +157,7 @@ def to_usgscsm(driver):
     if isinstance(driver, Radar):
         isd_data['name_model'] = 'USGS_ASTRO_SAR_SENSOR_MODEL'
         isd_data['starting_ephemeris_time'] = driver.ephemeris_start_time
+        isd_data['center_ephemeris_time'] = driver.center_ephemeris_time
         isd_data['ending_ephemeris_time'] = driver.ephemeris_stop_time
         isd_data['wavelength'] = driver.wavelength
         isd_data['line_exposure_duration'] = driver.line_exposure_duration


### PR DESCRIPTION
The center_ephemeris_time should be saved in the SAR sensor model, or else the SAR model will fail to be loaded, when the following code is encountered: 

https://github.com/USGS-Astrogeology/usgscsm/blob/da685687d4842d4f60d0a427348288517237664b/src/UsgsAstroSarSensorModel.cpp#L62