### PR TITLE
In support of a domain code review, fix spelling errors

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -21,7 +21,7 @@ text)](https://creativecommons.org/publicdomain/zero/1.0/legalcode).
 
 ### No Copyright
 
-The authors have associated their contributions to the ISIS project
+The authors have associated their contributions to the ALE project
 with this deed, and have dedicated the work to the public domain
 by waiving all of their rights to the work worldwide under copyright
 law, including all related and neighboring rights, to the extent

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ make
 ```
 
 Keep in mind that you will need to clone the repository with the `--recursive` flag in order to
-retrieve the gtest submodule for testing. If you have already cloned without the `--recusive` flag,
+retrieve the gtest submodule for testing. If you have already cloned without the `--recursive` flag,
 running the following command will retrieve the gtest submodule manually:
 ```bash
 git submodule update --init --recursive

--- a/ale/base/base.py
+++ b/ale/base/base.py
@@ -251,7 +251,7 @@ class Driver():
         -------
         : list
           3 element list containing affine transformation coefficient.
-          The elements are as follows: constant, x coefficent, y coeffecient
+          The elements are as follows: constant, x coefficient, y coefficient
         """
         raise NotImplementedError
 
@@ -262,7 +262,7 @@ class Driver():
         -------
         : list
           3 element list containing affine transformation coefficients.
-          The elements are as follows: constant, x coefficent, y coeffecient
+          The elements are as follows: constant, x coefficient, y coefficient
         """
         raise NotImplementedError
 
@@ -272,7 +272,7 @@ class Driver():
         Returns
         -------
         : list
-          3 element list containing coefficience for the pixels to focal plane
+          3 element list containing coefficients for the pixels to focal plane
           transformation. The elements are as follows: constant, sample, line
         """
         raise NotImplementedError
@@ -283,7 +283,7 @@ class Driver():
         Returns
         -------
         : : list
-          3 element list containing coefficience for the pixels to focal plane
+          3 element list containing coefficients for the pixels to focal plane
           transformation. The elements are as follows: constant, sample, line
         """
         raise NotImplementedError

--- a/ale/base/data_isis.py
+++ b/ale/base/data_isis.py
@@ -290,7 +290,7 @@ class IsisSpice():
         The hex encoded image start time computed from the
         spacecraft clock count
         Expects naif_keywords to be defined. This should be a dict containing
-        Naif keyworkds from the label.
+        Naif keywords from the label.
 
         Returns
         -------
@@ -403,7 +403,7 @@ class IsisSpice():
         The line component of the affine transformation
         from focal plane coordinates to centered ccd pixels
         Expects naif_keywords to be defined. This should be a dict containing
-        Naif keyworkds from the label.
+        Naif keywords from the label.
         Expects ikid to be defined. This should be the integer Naif ID code
         for the instrument.
 
@@ -421,7 +421,7 @@ class IsisSpice():
         The sample component of the affine transformation
         from focal plane coordinates to centered ccd pixels
         Expects naif_keywords to be defined. This should be a dict containing
-        Naif keyworkds from the label.
+        Naif keywords from the label.
         Expects ikid to be defined. This should be the integer Naif ID code
         for the instrument.
 
@@ -464,7 +464,7 @@ class IsisSpice():
         """
         The focal length of the instrument
         Expects naif_keywords to be defined. This should be a dict containing
-        Naif keyworkds from the label.
+        Naif keywords from the label.
         Expects ikid to be defined. This should be the integer Naif ID code
         for the instrument.
 
@@ -480,7 +480,7 @@ class IsisSpice():
         """
         The triaxial radii of the target body
         Expects naif_keywords to be defined. This should be a dict containing
-        Naif keyworkds from the label.
+        Naif keywords from the label.
 
         Returns
         -------

--- a/ale/base/data_naif.py
+++ b/ale/base/data_naif.py
@@ -45,7 +45,7 @@ class NaifSpice():
            the path to a directory that contains directories whose naming
            convention matches the PDS Kernel Archives format,
            `shortMissionName-versionInfo`. The directory corresponding to the
-           driver's mission will be searched for the approriate meta kernel to
+           driver's mission will be searched for the appropriate meta kernel to
            load.
 
         See Also
@@ -78,7 +78,7 @@ class NaifSpice():
     @property
     def light_time_correction(self):
         """
-        Returns the type of light time correciton and abberation correction to
+        Returns the type of light time correction and abberation correction to
         use in NAIF calls. Expects ikid to be defined. This must be the integer
         Naif id code of the instrument.
 
@@ -147,7 +147,7 @@ class NaifSpice():
         Returns
         -------
         : int
-          Naif ID used to for indentifying the instrument in Spice kernels
+          Naif ID used to for identifying the instrument in Spice kernels
         """
         return spice.bods2c(self.instrument_id)
 
@@ -169,7 +169,7 @@ class NaifSpice():
     def target_id(self):
         """
         Returns the Naif ID code for the target body
-        Expects target_name to be defined. This must be a string containig the name
+        Expects target_name to be defined. This must be a string containing the name
         of the target body.
 
         Returns
@@ -317,7 +317,7 @@ class NaifSpice():
         Returns a tuple with information detailing the sun position at the time
         of the image. Expects center_ephemeris_time to be defined. This must be
         a floating point number containing the average of the start and end ephemeris time.
-        Expects reference frame to be defined. This must be a sring containing the name of
+        Expects reference frame to be defined. This must be a string containing the name of
         the target reference frame. Expects target_name to be defined. This must be
         a string containing the name of the target body.
 
@@ -350,7 +350,7 @@ class NaifSpice():
         of the image. Expects ephemeris_time to be defined. This must be a floating point number
         containing the ephemeris time. Expects spacecraft_name to be defined. This must be a
         string containing the name of the spacecraft containing the sensor. Expects
-        reference_frame to be defined. This must be a sring containing the name of
+        reference_frame to be defined. This must be a string containing the name of
         the target reference frame. Expects target_name to be defined. This must be
         a string containing the name of the target body.
 

--- a/ale/base/label_pds3.py
+++ b/ale/base/label_pds3.py
@@ -163,9 +163,9 @@ class Pds3Label():
     @property
     def target_name(self):
         """
-        Returns a target name unquely identifying what an observation was capturing.
+        Returns a target name uniquely identifying what an observation was capturing.
         This is most often a body name (e.g., Mars, Moon, Europa). This value is often
-        use to acquire Ephermis data from SPICE files; therefore it should be the same
+        use to acquire Ephemeris data from SPICE files; therefore it should be the same
         name spicelib expects in bodvrd calls.
 
         Returns

--- a/ale/base/type_sensor.py
+++ b/ale/base/type_sensor.py
@@ -159,7 +159,7 @@ class Radar():
     @property
     def wavelength(self):
         """
-        Returns the wavelength used for image acquistion.
+        Returns the wavelength used for image acquisition.
 
         Returns
         -------
@@ -178,7 +178,7 @@ class Radar():
         : double
           Exposure duration for a line
         """
-        raise NotImplmentedError
+        raise NotImplementedError
 
 
     @property

--- a/ale/drivers/__init__.py
+++ b/ale/drivers/__init__.py
@@ -60,7 +60,7 @@ def load(label, props={}, formatter='ale', verbose=False):
     This function opens up the label file and attempts to produce an ISD in the
     format specified using the supplied properties. Drivers are tried sequentially
     until an ISD is successfully created. Drivers that use external ephemeris
-    data are tested before drivers that use attached epehemeris data.
+    data are tested before drivers that use attached ephemeris data.
 
     Parameters
     ----------

--- a/ale/drivers/co_drivers.py
+++ b/ale/drivers/co_drivers.py
@@ -72,7 +72,7 @@ nac_filter_to_focal_length = {
     ("IRP0","MT2"):2002.72,
     ("IRP0","MT3"):2002.72,
     ("P120","BL2"):2002.11,
-    ("P120","CB1"):002.28,
+    ("P120","CB1"):2002.28,
     ("P120","GRN"):2002.38,
     ("P120","IR1"):2002.39,
     ("P120","MT1"):2002.54,
@@ -119,7 +119,7 @@ class CassiniIssPds3LabelNaifSpiceDriver(Framer, Pds3Label, NaifSpice, RadialDis
     @property
     def instrument_id(self):
         """
-        Returns an instrument id for unquely identifying the instrument, but often
+        Returns an instrument id for uniquely identifying the instrument, but often
         also used to be piped into Spice Kernels to acquire instrument kernel (IK) NAIF IDs.
         Therefore they use the same NAIF ID asin bods2c calls. Expects instrument_id to be
         defined from a mixin class. This should return a string containing either 'ISSNA' or
@@ -213,7 +213,7 @@ class CassiniIssPds3LabelNaifSpiceDriver(Framer, Pds3Label, NaifSpice, RadialDis
     # number, so the order doesn't matter
     def detector_center_line(self):
         """
-        Dectector center based on ISIS's corrected values.
+        Detector center based on ISIS's corrected values.
 
         Returns
         -------
@@ -227,7 +227,7 @@ class CassiniIssPds3LabelNaifSpiceDriver(Framer, Pds3Label, NaifSpice, RadialDis
     # number, so the order doesn't matter
     def detector_center_sample(self):
         """
-        Dectector center based on ISIS's corrected values.
+        Detector center based on ISIS's corrected values.
 
         Returns
         -------
@@ -253,7 +253,7 @@ class CassiniIssPds3LabelNaifSpiceDriver(Framer, Pds3Label, NaifSpice, RadialDis
         """
         NAC uses multiple filter pairs, each filter combination has a different focal length.
         NAIF's Cassini kernels do not contain focal lengths for NAC filters and
-        so we aquired updated NAC filter data from ISIS's IAK kernel.
+        so we acquired updated NAC filter data from ISIS's IAK kernel.
 
         """
         # default focal defined by IK kernel
@@ -365,7 +365,7 @@ class CassiniIssIsisLabelIsisSpiceDriver(Framer, IsisLabel, IsisSpice, NoDistort
         """
         Returns the middle exposure time for the image in ephemeris seconds.
 
-        This is overriden because the ISIS ISSNAC and ISSWAC sensor models use the
+        This is overridden because the ISIS ISSNAC and ISSWAC sensor models use the
         label utc times so the converted times are not available in the
         NaifKeywords. Instead we get it from the tables.
 

--- a/ale/drivers/dawn_drivers.py
+++ b/ale/drivers/dawn_drivers.py
@@ -58,10 +58,10 @@ class DawnFcPds3NaifSpiceDriver(Framer, Pds3Label, NaifSpice, Driver):
     @property
     def target_name(self):
         """
-        Returns an target name for unquely identifying the instrument, but often
-        piped into Spice Kernels to acquire Ephermis data from Spice. Therefore they
+        Returns an target name for uniquely identifying the instrument, but often
+        piped into Spice Kernels to acquire Ephemeris data from Spice. Therefore they
         the same ID the Spice expects in bodvrd calls. In this case, vesta images
-        have a number infront of them like "4 VESTA" which needs to be simplified
+        have a number in front of them like "4 VESTA" which needs to be simplified
         to "VESTA" for spice. Expects target_name to be defined in the Pds3Label mixin.
         This should be a string containing the name of the target body.
 
@@ -168,7 +168,7 @@ class DawnFcPds3NaifSpiceDriver(Framer, Pds3Label, NaifSpice, Driver):
     def detector_center_sample(self):
         """
         Returns center detector sample acquired from Spice Kernels.
-        Expects ikid to be defined. This should be the integer Naid ID code for
+        Expects ikid to be defined. This should be the integer Naif ID code for
         the instrument.
 
         We have to add 0.5 to the CCD Center because the Dawn IK defines the
@@ -186,7 +186,7 @@ class DawnFcPds3NaifSpiceDriver(Framer, Pds3Label, NaifSpice, Driver):
     def detector_center_line(self):
         """
         Returns center detector line acquired from Spice Kernels.
-        Expects ikid to be defined. This should be the integer Naid ID code for
+        Expects ikid to be defined. This should be the integer Naif ID code for
         the instrument.
 
         We have to add 0.5 to the CCD Center because the Dawn IK defines the

--- a/ale/drivers/isis_ideal_drivers.py
+++ b/ale/drivers/isis_ideal_drivers.py
@@ -171,7 +171,7 @@ class IdealLsIsisLabelIsisSpiceDriver(LineScanner, IsisSpice, IsisLabel, NoDisto
         """
         The focal length of the instrument
         Expects naif_keywords to be defined. This should be a dict containing
-        Naif keyworkds from the label.
+        Naif keywords from the label.
 
         Returns
         -------

--- a/ale/drivers/juno_drivers.py
+++ b/ale/drivers/juno_drivers.py
@@ -28,7 +28,7 @@ class JunoJunoCamIsisLabelNaifSpiceDriver(Framer, IsisLabel, NaifSpice, NoDistor
     def ephemeris_start_time(self):
         """
         Junos camera is split into stacked frames where an image is made
-        of sets of RGBM chuncks. We need to account for these chuncks since
+        of sets of RGBM chunks. We need to account for these chunks since
         ISIS produces some number of cubes N where N = M*4.
         Computation obtained from JunoCamera.cpp
 

--- a/ale/drivers/lro_drivers.py
+++ b/ale/drivers/lro_drivers.py
@@ -17,7 +17,7 @@ from ale.base.type_sensor import LineScanner, Radar
 class LroLrocPds3LabelNaifSpiceDriver(LineScanner, NaifSpice, Pds3Label, Driver):
     """
     Driver for reading LROC NACL, NACR (not WAC, it is a push frame) labels. Requires a Spice mixin to
-    acquire addtional ephemeris and instrument data located exclusively in SPICE kernels, A PDS3 label,
+    acquire additional ephemeris and instrument data located exclusively in SPICE kernels, A PDS3 label,
     and the LineScanner and Driver bases.
     """
 
@@ -102,7 +102,7 @@ class LroLrocPds3LabelNaifSpiceDriver(LineScanner, NaifSpice, Pds3Label, Driver)
     @property
     def light_time_correction(self):
         """
-        Returns the type of light time correciton and abberation correction to
+        Returns the type of light time correction and abberation correction to
         use in NAIF calls.
 
         LROC is specifically set to not use light time correction because it is
@@ -221,7 +221,7 @@ class LroLrocPds3LabelNaifSpiceDriver(LineScanner, NaifSpice, Pds3Label, Driver)
         Returns
         -------
         : float
-          Returns the additionl preroll.
+          Returns the additional preroll.
         """
         return 1024.0
 
@@ -343,7 +343,7 @@ class LroLrocIsisLabelNaifSpiceDriver(LineScanner, NaifSpice, IsisLabel, Driver)
     @property
     def light_time_correction(self):
         """
-        Returns the type of light time correciton and abberation correction to
+        Returns the type of light time correction and abberation correction to
         use in NAIF calls.
 
         LROC is specifically set to not use light time correction because it is
@@ -462,7 +462,7 @@ class LroLrocIsisLabelNaifSpiceDriver(LineScanner, NaifSpice, IsisLabel, Driver)
         Returns
         -------
         : float
-          Returns the additionl preroll.
+          Returns the additional preroll.
         """
         return 1024.0
 
@@ -659,7 +659,7 @@ class LroLrocIsisLabelIsisSpiceDriver(LineScanner, IsisSpice, IsisLabel, Driver)
         Returns
         -------
         : float
-          Returns the additionl preroll.
+          Returns the additional preroll.
         """
         return 1024.0
 
@@ -728,7 +728,7 @@ class LroMiniRfIsisLabelNaifSpiceDriver(Radar, NaifSpice, IsisLabel, Driver):
     @property
     def wavelength(self):
         """
-        Returns the wavelength in meters used for image acquistion.
+        Returns the wavelength in meters used for image acquisition.
 
         Returns
         -------

--- a/ale/drivers/mess_drivers.py
+++ b/ale/drivers/mess_drivers.py
@@ -40,7 +40,7 @@ class MessengerMdisIsisLabelIsisSpiceDriver(Framer, IsisLabel, IsisSpice, NoDist
         Naif ID code used in calculating focal length
         Expects filter_number to be defined. This should be an integer containing
         the filter number from the pds3 label.
-        Expects ikid to be defined. This should be the integer Naid ID code for
+        Expects ikid to be defined. This should be the integer Naif ID code for
         the instrument.
 
         Returns
@@ -59,7 +59,7 @@ class MessengerMdisIsisLabelIsisSpiceDriver(Framer, IsisLabel, IsisSpice, NoDist
     @property
     def instrument_id(self):
         """
-        Returns an instrument id for unquely identifying the instrument, but often
+        Returns an instrument id for uniquely identifying the instrument, but often
         also used to be piped into Spice Kernels to acquire IKIDs. Therefore they
         the same ID the Spice expects in bods2c calls.
         Expects instrument_id to be defined in the Pds3Label mixin. This should
@@ -75,7 +75,7 @@ class MessengerMdisIsisLabelIsisSpiceDriver(Framer, IsisLabel, IsisSpice, NoDist
 
 class MessengerMdisPds3NaifSpiceDriver(Framer, Pds3Label, NaifSpice, NoDistortion, Driver):
     """
-    Driver for reading MDIS PDS3 labels. Requires a Spice mixin to acquire addtional
+    Driver for reading MDIS PDS3 labels. Requires a Spice mixin to acquire additional
     ephemeris and instrument data located exclusively in spice kernels.
     """
 
@@ -99,7 +99,7 @@ class MessengerMdisPds3NaifSpiceDriver(Framer, Pds3Label, NaifSpice, NoDistortio
         Naif ID code used in calculating focal length
         Expects filter_number to be defined. This should be an integer containing
         the filter number from the pds3 label.
-        Expects ikid to be defined. This should be the integer Naid ID code for
+        Expects ikid to be defined. This should be the integer Naif ID code for
         the instrument.
 
         Returns
@@ -118,7 +118,7 @@ class MessengerMdisPds3NaifSpiceDriver(Framer, Pds3Label, NaifSpice, NoDistortio
     @property
     def instrument_id(self):
         """
-        Returns an instrument id for unquely identifying the instrument, but often
+        Returns an instrument id for uniquely identifying the instrument, but often
         also used to be piped into Spice Kernels to acquire IKIDs. Therefore they
         the same ID the Spice expects in bods2c calls.
         Expects instrument_id to be defined in the Pds3Label mixin. This should
@@ -155,9 +155,9 @@ class MessengerMdisPds3NaifSpiceDriver(Framer, Pds3Label, NaifSpice, NoDistortio
         """
         Computes Focal Length from Kernels
 
-        MDIS has tempature dependant focal lengh and coefficients need to
+        MDIS has temperature dependant focal length and coefficients need to
         be acquired from IK Spice kernels (coeff describe focal length as a
-        function of tempature). Focal plane temps are acquired from a PDS3 label.
+        function of temperature). Focal plane temps are acquired from a PDS3 label.
 
         Returns
         -------
@@ -177,7 +177,7 @@ class MessengerMdisPds3NaifSpiceDriver(Framer, Pds3Label, NaifSpice, NoDistortio
     def detector_center_sample(self):
         """
         Returns center detector sample acquired from Spice Kernels.
-        Expects ikid to be defined. This should be the integer Naid ID code for
+        Expects ikid to be defined. This should be the integer Naif ID code for
         the instrument.
 
         NOTE: This value is defined in an ISIS iak as 512.5, but we subtract 0.5 from the
@@ -194,7 +194,7 @@ class MessengerMdisPds3NaifSpiceDriver(Framer, Pds3Label, NaifSpice, NoDistortio
     def detector_center_line(self):
         """
         Returns center detector line acquired from Spice Kernels.
-        Expects ikid to be defined. This should be the integer Naid ID code for
+        Expects ikid to be defined. This should be the integer Naif ID code for
         the instrument.
 
         NOTE: This value is defined in an ISIS iak as 512.5, but we subtract 0.5 from the
@@ -252,7 +252,7 @@ class MessengerMdisPds3NaifSpiceDriver(Framer, Pds3Label, NaifSpice, NoDistortio
 class MessengerMdisIsisLabelNaifSpiceDriver(IsisLabel, NaifSpice, Framer, NoDistortion, Driver):
     """
     Driver for reading MDIS ISIS3 Labels. These are Labels that have been ingested
-    into ISIS from PDS EDR images. Any SPCIE data attached by the spiceinit application
+    into ISIS from PDS EDR images. Any SPICE data attached by the spiceinit application
     will be ignored.
     """
     @property
@@ -331,7 +331,7 @@ class MessengerMdisIsisLabelNaifSpiceDriver(IsisLabel, NaifSpice, Framer, NoDist
         Naif ID code used in calculating focal length
         Expects filter_number to be defined. This should be an integer containing
         the filter number from the pds3 label.
-        Expects ikid to be defined. This should be the integer Naid ID code for
+        Expects ikid to be defined. This should be the integer Naif ID code for
         the instrument.
 
         Returns
@@ -351,9 +351,9 @@ class MessengerMdisIsisLabelNaifSpiceDriver(IsisLabel, NaifSpice, Framer, NoDist
         """
         Computes Focal Length from Kernels
 
-        MDIS has tempature dependant focal lengh and coefficients need to
+        MDIS has temperature dependant focal length and coefficients need to
         be acquired from IK Spice kernels (coeff describe focal length as a
-        function of tempature). Focal plane temps are acquired from a PDS3 label.
+        function of temperature). Focal plane temps are acquired from a PDS3 label.
 
         Returns
         -------
@@ -372,7 +372,7 @@ class MessengerMdisIsisLabelNaifSpiceDriver(IsisLabel, NaifSpice, Framer, NoDist
     def detector_center_sample(self):
         """
         Returns center detector sample acquired from Spice Kernels
-        Expects ikid to be defined. This should be the integer Naid ID code for
+        Expects ikid to be defined. This should be the integer Naif ID code for
         the instrument.
 
         We subtract 0.5 from the ISIS center sample because ISIS detector
@@ -390,7 +390,7 @@ class MessengerMdisIsisLabelNaifSpiceDriver(IsisLabel, NaifSpice, Framer, NoDist
     def detector_center_line(self):
         """
         Returns center detector line acquired from Spice Kernels
-        Expects ikid to be defined. This should be the integer Naid ID code for
+        Expects ikid to be defined. This should be the integer Naif ID code for
         the instrument.
 
         We subtract 0.5 from the ISIS center line because ISIS detector
@@ -416,7 +416,7 @@ class MessengerMdisIsisLabelNaifSpiceDriver(IsisLabel, NaifSpice, Framer, NoDist
     @property
     def pixel_size(self):
         """
-        Overriden because the MESSENGER IK uses PIXEL_PITCH and the units
+        Overridden because the MESSENGER IK uses PIXEL_PITCH and the units
         are already millimeters
 
         Returns

--- a/ale/drivers/mex_drivers.py
+++ b/ale/drivers/mex_drivers.py
@@ -113,7 +113,7 @@ class MexHrscPds3NaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, RadialDistor
         Returns
         -------
         : int
-          Naif ID used to for indentifying the instrument in Spice kernels
+          Naif ID used to for identifying the instrument in Spice kernels
         """
         return spice.bods2c("MEX_HRSC_HEAD")
 
@@ -125,7 +125,7 @@ class MexHrscPds3NaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, RadialDistor
 
         Expects filter_number to be defined. This should be an integer containing
         the filter number from the pds3 label.
-        Expects ikid to be defined. This should be the integer Naid ID code for
+        Expects ikid to be defined. This should be the integer Naif ID code for
         the instrument.
 
         Returns
@@ -210,7 +210,7 @@ class MexHrscPds3NaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, RadialDistor
     def focal2pixel_lines(self):
         """
         Expects fikid to be defined. This must be the integer Naif id code of
-        the filter-sepcific instrument.
+        the filter-specific instrument.
 
         NOTE: These values are pulled from ISIS iak kernels.
 
@@ -226,7 +226,7 @@ class MexHrscPds3NaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, RadialDistor
     def focal2pixel_samples(self):
         """
         Expects fikid to be defined. This must be the integer Naif id code of
-        the filter-sepcific instrument.
+        the filter-specific instrument.
 
         NOTE: These values are pulled from ISIS iak kernels.
 
@@ -311,7 +311,7 @@ class MexHrscPds3NaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, RadialDistor
         stored in the image data.
 
         In the image, every line has an entry. This method goes through
-        and removes conescutive lines with the same exposure duration.
+        and removes consecutive lines with the same exposure duration.
         There are also potentially missing lines in the image which this
         method accounts for.
 
@@ -346,7 +346,7 @@ class MexHrscPds3NaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, RadialDistor
         Returns the exposure durations taken from the binary image data.
 
         For HRSC, the exposure durations are imbedded in the binary data of the image.
-        The expsoure durations start at the 9th byte of the line/record and are 4 bytes long.
+        The exposure durations start at the 9th byte of the line/record and are 4 bytes long.
 
         Returns
         -------
@@ -556,7 +556,7 @@ class MexHrscIsisLabelNaifSpiceDriver(LineScanner, IsisLabel, NaifSpice, RadialD
   @property
   def times_table(self):
       """
-      Returns EphermisTime, ExposureTime, and LinesStart informtation which was stored as
+      Returns EphemerisTime, ExposureTime, and LinesStart informtation which was stored as
       binary information in the ISIS cube.
 
       Returns
@@ -609,7 +609,7 @@ class MexHrscIsisLabelNaifSpiceDriver(LineScanner, IsisLabel, NaifSpice, RadialD
       Returns
       -------
       : int
-        Naif ID used to for indentifying the instrument in Spice kernels
+        Naif ID used to for identifying the instrument in Spice kernels
       """
       return spice.bods2c("MEX_HRSC_HEAD")
 
@@ -683,7 +683,7 @@ class MexSrcPds3NaifSpiceDriver(Framer, Pds3Label, NaifSpice, RadialDistortion, 
         Returns
         -------
         : int
-          Naif ID used to for indentifying the instrument in Spice kernels
+          Naif ID used to for identifying the instrument in Spice kernels
         """
         return spice.bods2c("MEX_HRSC_SRC")
 

--- a/ale/drivers/mro_drivers.py
+++ b/ale/drivers/mro_drivers.py
@@ -110,7 +110,7 @@ class MroCtxIsisLabelNaifSpiceDriver(LineScanner, IsisLabel, NaifSpice, RadialDi
     def ephemeris_stop_time(self):
         """
         ISIS doesn't preserve the spacecraft stop count that we can use to get
-        the ephemeris stop time of the image, so compute the epehemris stop time
+        the ephemeris stop time of the image, so compute the ephemeris stop time
         from the start time and the exposure duration.
         """
         return self.ephemeris_start_time + self.exposure_duration * self.image_lines
@@ -168,7 +168,7 @@ class MroCtxIsisLabelNaifSpiceDriver(LineScanner, IsisLabel, NaifSpice, RadialDi
 
 class MroCtxPds3LabelNaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, RadialDistortion, Driver):
     """
-    Driver for reading CTX PDS3 labels. Requires a Spice mixin to acquire addtional
+    Driver for reading CTX PDS3 labels. Requires a Spice mixin to acquire additional
     ephemeris and instrument data located exclusively in spice kernels.
     """
 

--- a/ale/drivers/selene_drivers.py
+++ b/ale/drivers/selene_drivers.py
@@ -17,8 +17,8 @@ class KaguyaTcPds3NaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, Driver):
     NOTES
     -----
 
-    * Kaguaya has adjusted values for some of its keys, usually suffixed with `CORRECTED_`.
-      These corrected values should always be preffered over the original values.
+    * Kaguya has adjusted values for some of its keys, usually suffixed with `CORRECTED_`.
+      These corrected values should always be preferred over the original values.
 
     * The Kaguya TC doesn't use a generic Distortion Model, uses on unique to the TC.
       Therefore, methods normally in the Distortion classes are reimplemented here.
@@ -119,7 +119,7 @@ class KaguyaTcPds3NaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, Driver):
         for capturing the image.
 
         Some keys are stored in the IK kernel under a general ikid for TC1/TC2
-        presumably because they are not affected by the addtional parameters encoded in
+        presumably because they are not affected by the additional parameters encoded in
         the ikid returned by self.ikid. This method exists for those gdpool calls.
 
         Expects instrument_id to be defined in the Pds3Label mixin. This should be
@@ -328,7 +328,7 @@ class KaguyaTcPds3NaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, Driver):
         """
         # It's a list, but only sometimes.
         # seems to depend on whether you are using the original zipped archives or
-        # if its downloaded from Jaxa's image search:
+        # if its downloaded from JAXA's image search:
         # (https://darts.isas.jaxa.jp/planet/pdap/selene/product_search.html#)
         try:
             return self.label['CORRECTED_SAMPLING_INTERVAL'][0].value * 0.001 # Scale to seconds
@@ -782,7 +782,7 @@ class KaguyaMiPds3NaifSpiceDriver(LineScanner, Pds3Label, NaifSpice, Driver):
         """
         # It's a list, but only sometimes.
         # seems to depend on whether you are using the original zipped archives or
-        # if its downloaded from Jaxa's image search:
+        # if its downloaded from JAXA's image search:
         # (https://darts.isas.jaxa.jp/planet/pdap/selene/product_search.html#)
         try:
             return self.label['CORRECTED_SAMPLING_INTERVAL'][0].value * 0.001 # Scale to seconds
@@ -1130,7 +1130,7 @@ class KaguyaMiIsisLabelNaifSpiceDriver(LineScanner, NaifSpice, IsisLabel, Driver
         """
         # It's a list, but only sometimes.
         # seems to depend on whether you are using the original zipped archives or
-        # if its downloaded from Jaxa's image search:
+        # if its downloaded from JAXA's image search:
         # (https://darts.isas.jaxa.jp/planet/pdap/selene/product_search.html#)
         try:
             return self.label['IsisCube']['Instrument']['CorrectedSamplingInterval'][0].value * 0.001 # Scale to seconds

--- a/ale/drivers/viking_drivers.py
+++ b/ale/drivers/viking_drivers.py
@@ -30,7 +30,7 @@ class VikingIsisLabelNaifSpiceDriver(Framer, IsisLabel, NaifSpice, Driver):
     @property
     def instrument_id(self):
         """
-        Overriden to check that the instrument ID is correct
+        Overridden to check that the instrument ID is correct
 
         Returns
         -------

--- a/ale/util.py
+++ b/ale/util.py
@@ -32,7 +32,7 @@ def get_metakernels(spice_dir=spice_root, missions=set(), years=set(), versions=
     Parameters
     ----------
     spice_dir : str
-                Path containing Spice directories downlaoded from NAIF's website
+                Path containing Spice directories downloaded from NAIF's website
 
     missions : set, str
                Mission or set of missions to search for
@@ -167,12 +167,12 @@ def dict_to_lower(d):
     return {k.lower():v if not isinstance(v, dict) else dict_to_lower(v) for k,v in d.items()}
 
 
-def expandvars(path, env_dict=os.environ, default=None, case_sensative=True):
-    user_dict = env_dict if case_sensative else dict_to_lower(env_dict)
+def expandvars(path, env_dict=os.environ, default=None, case_sensitive=True):
+    user_dict = env_dict if case_sensitive else dict_to_lower(env_dict)
 
     def replace_var(m):
-        group0 = m.group(0) if case_sensative else m.group(0).lower()
-        group1 = m.group(1) if case_sensative else m.group(1).lower()
+        group0 = m.group(0) if case_sensitive else m.group(0).lower()
+        group1 = m.group(1) if case_sensitive else m.group(1).lower()
 
         return user_dict.get(m.group(2) or group1, group0 if default is None else default)
     reVar = r'\$(\w+|\{([^}]*)\})'
@@ -190,7 +190,7 @@ def generate_kernels_from_cube(cube,  expand=False, format_as='list'):
     expand : bool, optional
         Whether or not to expand variables within kernel paths based on your IsisPreferences file.
     format_as : str, optional {'list', 'dict'}
-        How to return the kernels: either as a one-demensional ordered list, or as a dictionary
+        How to return the kernels: either as a one-dimensional ordered list, or as a dictionary
         of kernel lists.
 
     Returns

--- a/code.json
+++ b/code.json
@@ -2,7 +2,7 @@
   {
     "name": "ale",
     "organization": "U.S. Geological Survey",
-    "description": "GitHub respository for the Abstraction Layer for Ephemerides package",
+    "description": "GitHub repository for the Abstraction Layer for Ephemerides package",
     "version": "0.8.7",
     "status": "Production",
 

--- a/tests/pytests/test_cassini_drivers.py
+++ b/tests/pytests/test_cassini_drivers.py
@@ -33,10 +33,10 @@ def test_load_isis():
     label_file = get_image_label("N1702360370_1", label_type="isis3")
     compare_dict = get_isd("cassiniiss_isis")
 
-    def read_detatched_table(table_label, cube):
+    def read_detached_table(table_label, cube):
         return get_table_data("N1702360370_1", table_label["Name"])
 
-    with patch('ale.base.data_isis.read_table_data', side_effect=read_detatched_table):
+    with patch('ale.base.data_isis.read_table_data', side_effect=read_detached_table):
         isd_str = ale.loads(label_file)
     isd_obj = json.loads(isd_str)
     print(json.dumps(isd_obj, indent=2))

--- a/tests/pytests/test_load.py
+++ b/tests/pytests/test_load.py
@@ -83,7 +83,7 @@ def test_load_mes_with_no_metakernels(tmpdir, monkeypatch, mess_kernels):
     label_file = get_image_label('EN1072174528M')
     tmpdir.mkdir('mes')
 
-    # intentially make an mk file with wrong year
+    # intentionally make an mk file with wrong year
     with open(tmpdir.join('mes', 'mes_2016_v1.tm'), 'w+') as mk_file:
         mk_str = util.write_metakernel_from_kernel_list(updated_kernels)
         print(mk_str)

--- a/tests/pytests/test_lro_drivers.py
+++ b/tests/pytests/test_lro_drivers.py
@@ -44,7 +44,7 @@ def test_load(test_kernels, label_type, image, kernel_type):
         compare_isd = image_dict[image]
     else: 
         label_file = get_image(image)
-        isd_str = ale.loads(label_file);
+        isd_str = ale.loads(label_file)
         compare_isd = get_isd('lro_isis')
 
     isd_obj = json.loads(isd_str)

--- a/tests/pytests/test_util.py
+++ b/tests/pytests/test_util.py
@@ -277,10 +277,10 @@ def test_get_prefrences_malformed_files(monkeypatch, tmpdir, filename):
         util.get_isis_preferences(tmpdir.join(filename))
 
 
-@pytest.mark.parametrize('string,expected,case_sensative', [('$bar/baz', '/bar/baz', False), ('$bar/$foo/baz', '/bar//foo/baz', True), ('$BAR/$FOO/baz', '/bar//foo/baz', False)])
-def test_expand_vars(string, expected, case_sensative):
+@pytest.mark.parametrize('string,expected,case_sensitive', [('$bar/baz', '/bar/baz', False), ('$bar/$foo/baz', '/bar//foo/baz', True), ('$BAR/$FOO/baz', '/bar//foo/baz', False)])
+def test_expand_vars(string, expected, case_sensitive):
     user_vars = {'foo': '/foo', 'bar': '/bar'}
-    result = util.expandvars(string, env_dict=user_vars, case_sensative=case_sensative)
+    result = util.expandvars(string, env_dict=user_vars, case_sensitive=case_sensitive)
     assert result == expected
 
 


### PR DESCRIPTION
To support a domain code review, this commit largely addresses minor spelling issues in the code's comments. There are a few exceptions listed below.

- ale\base\type_sensor.py : typo fixed in the code line [181](https://github.com/USGS-Astrogeology/ale/blob/2856500286a51eab0b0039030e0f981a1afc3008/ale/base/type_sensor.py#L181)
- ale\drivers\co_drivers.py : apparent value typo in line [75](https://github.com/USGS-Astrogeology/ale/blob/2856500286a51eab0b0039030e0f981a1afc3008/ale/drivers/co_drivers.py#L75). please validate update.
- ale\util.py : internal only to the script, the function named "case_sensative" was updated to correct misspelling
- tests\pytests\test_cassini_drivers.py : internal only to the script (and test_util.py), the function named "read_detatched_table" was updated to correct misspelling
- tests\pytests\test_lro_drivers.py : unnecessary semicolon was removed.
- tests\pytests\test_util.py see _test_cassini_drivers.py_ for same update above.