### PR TITLE
Cahvor Model Mixin

### DIFF
--- a/ale/base/type_sensor.py
+++ b/ale/base/type_sensor.py
@@ -388,21 +388,49 @@ class Cahvor():
 
     def compute_h_c(self):
         """
+        Computes the h_c element of a cahvor model for the conversion
+        to a photogrametric model
+
+        Returns
+        -------
+        : float
+          Dot product of A and H vectors
         """
         return np.dot(self.cahvor_camera_dict['A'], self.cahvor_camera_dict['H'])
 
     def compute_h_s(self):
         """
+        Computes the h_s element of a cahvor model for the conversion
+        to a photogrametric model
+
+        Returns
+        -------
+        : float
+          Norm of the cross product of A and H vectors
         """
         return np.linalg.norm(np.cross(self.cahvor_camera_dict['A'], self.cahvor_camera_dict['H']))
 
     def compute_v_c(self):
         """
+        Computes the v_c element of a cahvor model for the conversion
+        to a photogrametric model
+
+        Returns
+        -------
+        : float
+          Dot product of A and V vectors
         """
         return np.dot(self.cahvor_camera_dict['A'], self.cahvor_camera_dict['V'])
 
     def compute_v_s(self):
         """
+        Computes the v_s element of a cahvor model for the conversion
+        to a photogrametric model
+
+        Returns
+        -------
+        : float
+          Norm of the cross product of A and V vectors
         """
         return np.linalg.norm(np.cross(self.cahvor_camera_dict['A'], self.cahvor_camera_dict['V']))
 

--- a/ale/base/type_sensor.py
+++ b/ale/base/type_sensor.py
@@ -1,7 +1,7 @@
 import math
 
 import numpy as np
-import spiceypy as spice
+from scipy.spatial.transform import Rotation
 
 from ale.transformation import FrameChain
 from ale.transformation import ConstantRotation
@@ -442,15 +442,13 @@ class Cahvor():
           A networkx frame chain object
         """
         if not hasattr(self, '_frame_chain'):
-            nadir = self._props.get('nadir', False)
-            exact_ck_times = self._props.get('exact_ck_times', True)
             self._frame_chain = FrameChain.from_spice(sensor_frame=self.ikid,
                                                       target_frame=self.target_frame_id,
                                                       center_ephemeris_time=self.center_ephemeris_time,
                                                       ephemeris_times=self.ephemeris_time,
-                                                      nadir=nadir, exact_ck_times=exact_ck_times)
+                                                      nadir=False, exact_ck_times=False)
             cahvor_quats = np.zeros(4)
-            cahvor_quat_from_rotation = spice.m2q(self.cahvor_rotation_matrix)
+            cahvor_quat_from_rotation = Rotation.from_matrix(self.cahvor_rotation_matrix).as_quat()
             cahvor_quats[:3] = cahvor_quat_from_rotation[1:]
             cahvor_quats[3] = cahvor_quat_from_rotation[0]
             cahvor_rotation = ConstantRotation(cahvor_quats, self.sensor_frame_id, self.ikid)

--- a/ale/base/type_sensor.py
+++ b/ale/base/type_sensor.py
@@ -447,10 +447,7 @@ class Cahvor():
                                                       center_ephemeris_time=self.center_ephemeris_time,
                                                       ephemeris_times=self.ephemeris_time,
                                                       nadir=False, exact_ck_times=False)
-            cahvor_quats = np.zeros(4)
-            cahvor_quat_from_rotation = Rotation.from_matrix(self.cahvor_rotation_matrix).as_quat()
-            cahvor_quats[:3] = cahvor_quat_from_rotation[1:]
-            cahvor_quats[3] = cahvor_quat_from_rotation[0]
+            cahvor_quats = Rotation.from_matrix(self.cahvor_rotation_matrix).as_quat()
             cahvor_rotation = ConstantRotation(cahvor_quats, self.sensor_frame_id, self.ikid)
             self._frame_chain.add_edge(rotation = cahvor_rotation)
         return self._frame_chain
@@ -458,17 +455,38 @@ class Cahvor():
     @property
     def detector_center_line(self):
         """
+        Computes the detector center line using the cahvor model.
+        Equation for computation comes from MSL instrument kernels
+
+        Returns
+        -------
+        : float
+          The detector center line/boresight center line
         """
         return np.dot(self.cahvor_camera_dict['V'], self.cahvor_camera_dict['A'])
 
     @property
     def detector_center_sample(self):
         """
+        Computes the detector center sample using the cahvor model.
+        Equation for computation comes from MSL instrument kernels
+
+        Returns
+        -------
+        : float
+          The detector center sample/boresight center sample
         """
         return np.dot(self.cahvor_camera_dict['H'], self.cahvor_camera_dict['A'])
 
     @property
     def pixel_size(self):
         """
+        Computes the pixel size given the focal length from spice kernels
+        or other sources
+
+        Returns
+        -------
+        : float
+          Focal length of a cahvor model instrument
         """
         return self.focal_length/np.linalg.norm(np.cross(self.cahvor_camera_dict['H'], self.cahvor_camera_dict['A']))

--- a/ale/base/type_sensor.py
+++ b/ale/base/type_sensor.py
@@ -470,7 +470,6 @@ class Cahvor():
             cahvor_quat_from_rotation = spice.m2q(self.cahvor_rotation_matrix)
             cahvor_quats[:3] = cahvor_quat_from_rotation[1:]
             cahvor_quats[3] = cahvor_quat_from_rotation[0]
-            print(self.sensor_frame_id)
             cahvor_rotation = ConstantRotation(cahvor_quats, self.sensor_frame_id, self.ikid)
             self._frame_chain.add_edge(rotation = cahvor_rotation)
         return self._frame_chain

--- a/ale/drivers/msl_drivers.py
+++ b/ale/drivers/msl_drivers.py
@@ -5,9 +5,10 @@ from ale.base.data_naif import NaifSpice
 from ale.base.label_pds3 import Pds3Label
 from ale.base.type_sensor import Framer
 from ale.base.type_distortion import NoDistortion
+from ale.base.type_sensor import Cahvor
 from ale.base.base import Driver
 
-class MslMastcamPds3NaifSpiceDriver(Framer, Pds3Label, NaifSpice, NoDistortion, Driver):
+class MslMastcamPds3NaifSpiceDriver(Cahvor, Framer, Pds3Label, NaifSpice, NoDistortion, Driver):
     @property
     def spacecraft_name(self):
         """

--- a/tests/pytests/test_cahvor_mixin.py
+++ b/tests/pytests/test_cahvor_mixin.py
@@ -47,11 +47,11 @@ class test_cahvor_sensor(unittest.TestCase):
 
     @patch("ale.base.type_sensor.Cahvor.cahvor_camera_dict", new_callable=PropertyMock, return_value=cahvor_camera_dict())
     def test_cahvor_detector_center_line(self, cahvor_camera_dict):
-        assert self.driver.detector_center_line == 590.1933422831007
+        np.testing.assert_almost_equal(self.driver.detector_center_line, 590.1933422831007)
     
     @patch("ale.base.type_sensor.Cahvor.cahvor_camera_dict", new_callable=PropertyMock, return_value=cahvor_camera_dict())
     def test_cahvor_detector_center_sample(self, cahvor_camera_dict):
-        assert self.driver.detector_center_sample == 673.4306859859296
+        np.testing.assert_almost_equal(self.driver.detector_center_sample, 673.4306859859296)
 
     @patch("ale.base.type_sensor.Cahvor.cahvor_camera_dict", new_callable=PropertyMock, return_value=cahvor_camera_dict())
     def test_cahvor_pixel_size(self, cahvor_camera_dict):

--- a/tests/pytests/test_cahvor_mixin.py
+++ b/tests/pytests/test_cahvor_mixin.py
@@ -1,0 +1,80 @@
+import unittest
+from unittest.mock import PropertyMock, patch
+import pvl
+import numpy as np
+
+import ale
+
+from ale.base.type_sensor import Cahvor
+
+cahvor_pvl = """
+GROUP                              = GEOMETRIC_CAMERA_MODEL_PARMS
+ ^MODEL_DESC                         = "GEOMETRIC_CM.TXT"
+ FILTER_NAME                         = MASTCAM_R0_CLEAR
+ MODEL_TYPE                          = CAHV
+ MODEL_COMPONENT_ID                  = ("C","A","H","V")
+ MODEL_COMPONENT_NAME                = ("CENTER", "AXIS",
+                                        "HORIZONTAL", "VERTICAL")
+ MODEL_COMPONENT_1                   = ( 6.831825e-01, 5.243722e-01,
+-1.955875e+00 )
+ MODEL_COMPONENT_2                   = ( -3.655151e-01, 5.396012e-01,
+7.584387e-01 )
+ MODEL_COMPONENT_3                   = ( -1.156881e+04, -7.518712e+03,
+6.618359e+02 )
+ MODEL_COMPONENT_4                   = ( 5.843885e+03, -8.213856e+03,
+9.438374e+03 )
+ REFERENCE_COORD_SYSTEM_NAME         = ROVER_NAV_FRAME
+ COORDINATE_SYSTEM_INDEX_NAME        = ("SITE", "DRIVE", "POSE",
+                                        "ARM", "CHIMRA", "DRILL",
+                                        "RSM", "HGA",
+                                        "DRT", "IC")
+ REFERENCE_COORD_SYSTEM_INDEX        = (62, 660, 8,
+                                        0, 0, 0,
+                                        306, 108,
+                                        0, 0 )
+END_GROUP                          = GEOMETRIC_CAMERA_MODEL_PARMS
+"""
+
+class test_cahvor_sensor(unittest.TestCase):
+
+    def setUp(self):
+        self.driver = Cahvor()
+        self.driver.label = pvl.loads(cahvor_pvl)
+        self.driver._props = {}
+        self.driver.ikid = -76220
+        self.driver.target_frame_id = 10014
+        self.driver.center_ephemeris_time = 0
+        self.driver.ephemeris_time = [0]
+
+
+    def test_cahvor_camera_group(self):
+        cahvor_camera_params = self.driver.cahvor_camera_params
+        assert len(cahvor_camera_params) == 4
+        np.testing.assert_allclose(cahvor_camera_params['C'], [6.831825e-01, 5.243722e-01, -1.955875e+00])
+        np.testing.assert_allclose(cahvor_camera_params['A'], [-3.655151e-01, 5.396012e-01, 7.584387e-01])
+        np.testing.assert_allclose(cahvor_camera_params['H'], [-1.156881e+04, -7.518712e+03, 6.618359e+02])
+        np.testing.assert_allclose(cahvor_camera_params['V'], [5.843885e+03, -8.213856e+03, 9.438374e+03])
+
+
+    def test_cahvor_rotation_matrix(self):
+        r_matrix = self.driver.cahvor_rotation_matrix
+        print(r_matrix)
+        np.testing.assert_allclose(r_matrix, [[-0.42447558, -0.7572992,  -0.49630475],
+                                              [ 0.73821222,  0.02793007, -0.67399009],
+                                              [ 0.52427398, -0.65247056,  0.54719189]])
+
+    @patch('ale.transformation.FrameChain.from_spice', return_value=ale.transformation.FrameChain())
+    @patch("ale.base.type_sensor.Cahvor.sensor_frame_id", new_callable=PropertyMock,return_value=-76562)
+    def test_cahvor_frame_chain(self, sensor_frame_id, from_spice):
+      frame_chain = self.driver.frame_chain
+      assert len(frame_chain.nodes()) == 2
+      assert -76220 in frame_chain.nodes()
+      assert -76562 in frame_chain.nodes()
+      from_spice.assert_called_with(center_ephemeris_time=0, ephemeris_times=[0], sensor_frame=-76220, target_frame=10014, nadir=False, exact_ck_times=True)
+      np.testing.assert_allclose(frame_chain[-76562][-76220]['rotation'].quat, [0.0100307131, -0.4757136116, 0.6970899144, 0.5363409323])
+
+
+    def test_sensor_frame_id(self):
+        with patch('ale.base.type_sensor.spice.bods2c', return_value=-76562) as bods2c:
+            assert self.driver.sensor_frame_id == -76562
+            bods2c.assert_called_with("MSL_SITE_62")

--- a/tests/pytests/test_cahvor_mixin.py
+++ b/tests/pytests/test_cahvor_mixin.py
@@ -29,15 +29,18 @@ class test_cahvor_sensor(unittest.TestCase):
         self.driver.ephemeris_time = [0]
 
     @patch("ale.base.type_sensor.Cahvor.cahvor_camera_dict", new_callable=PropertyMock, return_value=cahvor_camera_dict())
+    def test_compute_functions(self, cahvor_camera_dict):
+        np.testing.assert_almost_equal(self.driver.compute_h_s(), 13796.844341513603)
+        np.testing.assert_almost_equal(self.driver.compute_h_c(), 673.4306859859296)
+        np.testing.assert_almost_equal(self.driver.compute_v_s(), 13796.847423351614)
+        np.testing.assert_almost_equal(self.driver.compute_v_c(), 590.1933422831007)
+
+    @patch("ale.base.type_sensor.Cahvor.cahvor_camera_dict", new_callable=PropertyMock, return_value=cahvor_camera_dict())
     def test_cahvor_model_elements(self, cahvor_camera_dict):
-        cahvor_model = self.driver.cahvor_model_elements
-        np.testing.assert_almost_equal(cahvor_model["h_s"], 13796.844341513603)
-        np.testing.assert_almost_equal(cahvor_model["h_c"], 673.4306859859296)
-        np.testing.assert_almost_equal(cahvor_model["v_s"], 13796.847423351614)
-        np.testing.assert_almost_equal(cahvor_model["v_c"], 590.1933422831007)
-        np.testing.assert_allclose(cahvor_model["r_matrix"], [[-0.42447558, -0.7572992,  -0.49630475],
-                                              [ 0.73821222,  0.02793007, -0.67399009],
-                                              [ 0.52427398, -0.65247056,  0.54719189]])
+        cahvor_matrix = self.driver.cahvor_rotation_matrix
+        np.testing.assert_allclose(cahvor_matrix, [[-0.42447558, -0.7572992,  -0.49630475],
+                                                   [ 0.73821222,  0.02793007, -0.67399009],
+                                                   [ 0.52427398, -0.65247056,  0.54719189]])
 
     @patch('ale.transformation.FrameChain.from_spice', return_value=ale.transformation.FrameChain())
     @patch("ale.base.type_sensor.Cahvor.cahvor_camera_dict", new_callable=PropertyMock, return_value=cahvor_camera_dict())

--- a/tests/pytests/test_cahvor_mixin.py
+++ b/tests/pytests/test_cahvor_mixin.py
@@ -29,9 +29,13 @@ class test_cahvor_sensor(unittest.TestCase):
         self.driver.ephemeris_time = [0]
 
     @patch("ale.base.type_sensor.Cahvor.cahvor_camera_dict", new_callable=PropertyMock, return_value=cahvor_camera_dict())
-    def test_cahvor_rotation_matrix(self, cahvor_camera_dict):
-        r_matrix = self.driver.cahvor_rotation_matrix
-        np.testing.assert_allclose(r_matrix, [[-0.42447558, -0.7572992,  -0.49630475],
+    def test_cahvor_model_elements(self, cahvor_camera_dict):
+        cahvor_model = self.driver.cahvor_model_elements
+        np.testing.assert_almost_equal(cahvor_model["h_s"], 13796.844341513603)
+        np.testing.assert_almost_equal(cahvor_model["h_c"], 673.4306859859296)
+        np.testing.assert_almost_equal(cahvor_model["v_s"], 13796.847423351614)
+        np.testing.assert_almost_equal(cahvor_model["v_c"], 590.1933422831007)
+        np.testing.assert_allclose(cahvor_model["r_matrix"], [[-0.42447558, -0.7572992,  -0.49630475],
                                               [ 0.73821222,  0.02793007, -0.67399009],
                                               [ 0.52427398, -0.65247056,  0.54719189]])
 

--- a/tests/pytests/test_cahvor_mixin.py
+++ b/tests/pytests/test_cahvor_mixin.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest.mock import PropertyMock, patch
+import pytest
 import pvl
 import numpy as np
 
@@ -7,74 +8,51 @@ import ale
 
 from ale.base.type_sensor import Cahvor
 
-cahvor_pvl = """
-GROUP                              = GEOMETRIC_CAMERA_MODEL_PARMS
- ^MODEL_DESC                         = "GEOMETRIC_CM.TXT"
- FILTER_NAME                         = MASTCAM_R0_CLEAR
- MODEL_TYPE                          = CAHV
- MODEL_COMPONENT_ID                  = ("C","A","H","V")
- MODEL_COMPONENT_NAME                = ("CENTER", "AXIS",
-                                        "HORIZONTAL", "VERTICAL")
- MODEL_COMPONENT_1                   = ( 6.831825e-01, 5.243722e-01,
--1.955875e+00 )
- MODEL_COMPONENT_2                   = ( -3.655151e-01, 5.396012e-01,
-7.584387e-01 )
- MODEL_COMPONENT_3                   = ( -1.156881e+04, -7.518712e+03,
-6.618359e+02 )
- MODEL_COMPONENT_4                   = ( 5.843885e+03, -8.213856e+03,
-9.438374e+03 )
- REFERENCE_COORD_SYSTEM_NAME         = ROVER_NAV_FRAME
- COORDINATE_SYSTEM_INDEX_NAME        = ("SITE", "DRIVE", "POSE",
-                                        "ARM", "CHIMRA", "DRILL",
-                                        "RSM", "HGA",
-                                        "DRT", "IC")
- REFERENCE_COORD_SYSTEM_INDEX        = (62, 660, 8,
-                                        0, 0, 0,
-                                        306, 108,
-                                        0, 0 )
-END_GROUP                          = GEOMETRIC_CAMERA_MODEL_PARMS
-"""
+def cahvor_camera_dict():
+    camera_dict = {}
+    camera_dict['C'] = np.array([6.831825e-01, 5.243722e-01, -1.955875e+00])
+    camera_dict['A'] = np.array([-3.655151e-01, 5.396012e-01, 7.584387e-01])
+    camera_dict['H'] = np.array([-1.156881e+04, -7.518712e+03, 6.618359e+02])
+    camera_dict['V'] = np.array([5.843885e+03, -8.213856e+03, 9.438374e+03])
+    return camera_dict
+
 
 class test_cahvor_sensor(unittest.TestCase):
 
     def setUp(self):
         self.driver = Cahvor()
-        self.driver.label = pvl.loads(cahvor_pvl)
-        self.driver._props = {}
+        self.driver.focal_length = 100
         self.driver.ikid = -76220
+        self.driver.sensor_frame_id = -76562
         self.driver.target_frame_id = 10014
         self.driver.center_ephemeris_time = 0
         self.driver.ephemeris_time = [0]
 
-
-    def test_cahvor_camera_group(self):
-        cahvor_camera_params = self.driver.cahvor_camera_params
-        assert len(cahvor_camera_params) == 4
-        np.testing.assert_allclose(cahvor_camera_params['C'], [6.831825e-01, 5.243722e-01, -1.955875e+00])
-        np.testing.assert_allclose(cahvor_camera_params['A'], [-3.655151e-01, 5.396012e-01, 7.584387e-01])
-        np.testing.assert_allclose(cahvor_camera_params['H'], [-1.156881e+04, -7.518712e+03, 6.618359e+02])
-        np.testing.assert_allclose(cahvor_camera_params['V'], [5.843885e+03, -8.213856e+03, 9.438374e+03])
-
-
-    def test_cahvor_rotation_matrix(self):
+    @patch("ale.base.type_sensor.Cahvor.cahvor_camera_dict", new_callable=PropertyMock, return_value=cahvor_camera_dict())
+    def test_cahvor_rotation_matrix(self, cahvor_camera_dict):
         r_matrix = self.driver.cahvor_rotation_matrix
-        print(r_matrix)
         np.testing.assert_allclose(r_matrix, [[-0.42447558, -0.7572992,  -0.49630475],
                                               [ 0.73821222,  0.02793007, -0.67399009],
                                               [ 0.52427398, -0.65247056,  0.54719189]])
 
     @patch('ale.transformation.FrameChain.from_spice', return_value=ale.transformation.FrameChain())
-    @patch("ale.base.type_sensor.Cahvor.sensor_frame_id", new_callable=PropertyMock,return_value=-76562)
-    def test_cahvor_frame_chain(self, sensor_frame_id, from_spice):
+    @patch("ale.base.type_sensor.Cahvor.cahvor_camera_dict", new_callable=PropertyMock, return_value=cahvor_camera_dict())
+    def test_cahvor_frame_chain(self, cahvor_camera_dict, from_spice):
       frame_chain = self.driver.frame_chain
       assert len(frame_chain.nodes()) == 2
       assert -76220 in frame_chain.nodes()
       assert -76562 in frame_chain.nodes()
-      from_spice.assert_called_with(center_ephemeris_time=0, ephemeris_times=[0], sensor_frame=-76220, target_frame=10014, nadir=False, exact_ck_times=True)
+      from_spice.assert_called_with(center_ephemeris_time=0, ephemeris_times=[0], sensor_frame=-76220, target_frame=10014, nadir=False, exact_ck_times=False)
       np.testing.assert_allclose(frame_chain[-76562][-76220]['rotation'].quat, [0.0100307131, -0.4757136116, 0.6970899144, 0.5363409323])
 
+    @patch("ale.base.type_sensor.Cahvor.cahvor_camera_dict", new_callable=PropertyMock, return_value=cahvor_camera_dict())
+    def test_cahvor_detector_center_line(self, cahvor_camera_dict):
+        assert self.driver.detector_center_line == 590.1933422831007
+    
+    @patch("ale.base.type_sensor.Cahvor.cahvor_camera_dict", new_callable=PropertyMock, return_value=cahvor_camera_dict())
+    def test_cahvor_detector_center_sample(self, cahvor_camera_dict):
+        assert self.driver.detector_center_sample == 673.4306859859296
 
-    def test_sensor_frame_id(self):
-        with patch('ale.base.type_sensor.spice.bods2c', return_value=-76562) as bods2c:
-            assert self.driver.sensor_frame_id == -76562
-            bods2c.assert_called_with("MSL_SITE_62")
+    @patch("ale.base.type_sensor.Cahvor.cahvor_camera_dict", new_callable=PropertyMock, return_value=cahvor_camera_dict())
+    def test_cahvor_pixel_size(self, cahvor_camera_dict):
+        assert self.driver.pixel_size == 0.007248034226138798

--- a/tests/pytests/test_msl_drivers.py
+++ b/tests/pytests/test_msl_drivers.py
@@ -1,7 +1,6 @@
 import numpy as np
 import unittest
 
-import ale
 from ale.drivers.msl_drivers import MslMastcamPds3NaifSpiceDriver
 
 from conftest import get_image_label
@@ -33,10 +32,17 @@ class test_mastcam_pds_naif(unittest.TestCase):
         with patch('ale.drivers.msl_drivers.spice.bods2c', return_value=-76562) as bods2c:
             assert self.driver.sensor_frame_id == -76562
             bods2c.assert_called_with("MSL_SITE_62")
+    
+    def test_focal2pixel_lines(self):
+        with patch('ale.drivers.msl_drivers.spice.bods2c', new_callable=PropertyMock, return_value=-76220) as bods2c, \
+             patch('ale.drivers.msl_drivers.spice.gdpool', new_callable=PropertyMock, return_value=[100]) as gdpool:
+            np.testing.assert_allclose(self.driver.focal2pixel_lines, [0, 137.96844341513602, 0])
+            bods2c.assert_called_with('MSL_MASTCAM_RIGHT')
+            gdpool.assert_called_with('INS-76220_FOCAL_LENGTH', 0, 1)
 
-    # uncomment once cahvor mixin is merged
-    # def test_focal2pixel_lines(self):
-    #     np.testing.assert_allclose(self.driver.focal2pixel_lines, [0, 137968.44341513602, 0])
-
-    # def test_focal2pixel_samples(self):
-    #     np.testing.assert_allclose(self.driver.focal2pixel_samples, [137968.44341513602, 0, 0])
+    def test_focal2pixel_samples(self):
+        with patch('ale.drivers.msl_drivers.spice.bods2c', new_callable=PropertyMock, return_value=-76220) as bods2c, \
+             patch('ale.drivers.msl_drivers.spice.gdpool', new_callable=PropertyMock, return_value=[100]) as gdpool:
+            np.testing.assert_allclose(self.driver.focal2pixel_samples, [137.96844341513602, 0, 0])
+            bods2c.assert_called_with('MSL_MASTCAM_RIGHT')
+            gdpool.assert_called_with('INS-76220_FOCAL_LENGTH', 0, 1)


### PR DESCRIPTION
Adds a mixin for CAHVOR model instruments for use with largely rover data like MSL or MER.