### PR TITLE
Remove 3.7 CI add 3.11 CI

### DIFF
--- a/.github/workflows/ci_testing.yml
+++ b/.github/workflows/ci_testing.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
        os: [ubuntu-latest, macos-latest]
-       python-version: ["3.7", "3.8", "3.9", "3.10"]
+       python-version: ["3.8", "3.9", "3.10", "3.11"]
     defaults:
       run:
         shell: bash -l {0}


### PR DESCRIPTION
3.11 is out, so we should add it to the CI. We're having issues with the 3.7 linux environment taking too long to solve as it's no longer supported by conda-forge, so remove it in favor of 3.11